### PR TITLE
Support proxying multiple paths to different backends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
 RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \
  && chmod u+x /usr/local/bin/forego
 
-ENV DOCKER_GEN_VERSION 0.4.2
+ENV DOCKER_GEN_VERSION 0.4.3
 
 RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
  && tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -94,7 +94,7 @@ upstream {{ $host }} {
 {{ $default_server := index (dict $host "" $default_host "default_server") $host }}
 
 {{/* Get the VIRTUAL_PROTO defined by containers w/ the same vhost, falling back to "http" */}}
-{{ $proto := or (trim (first (groupByKeys $containers "Env.VIRTUAL_PROTO"))) "http" }}
+{{ $proto := trim (or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http") }}
 
 {{/* Get the first cert name defined by containers w/ the same vhost */}}
 {{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -1,3 +1,21 @@
+{{ define "upstream-block" }}
+upstream {{ .Host }}{{ .Suffix }} {
+{{ range $container := .Containers }}
+	{{ $addrLen := len $container.Addresses }}
+	{{/* If only 1 port exposed, use that */}}
+	{{ if eq $addrLen 1 }}
+		{{ $address := index $container.Addresses 0 }}
+		{{ template "upstream" (dict "Container" $container "Address" $address) }}
+	{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
+	{{ else }}
+		{{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
+		{{ $address := where $container.Addresses "Port" $port | first }}
+		{{ template "upstream" (dict "Container" $container "Address" $address) }}
+	{{ end }}
+{{ end }}
+}
+{{ end }}
+
 {{ define "upstream" }}
 	{{ if .Address }}
 		{{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
@@ -13,6 +31,21 @@
 		# {{ .Container.Name }}
 		server {{ .Container.IP }} down;
 	{{ end }}
+{{ end }}
+
+{{ define "location" }}
+	location {{ .Path }} {
+		proxy_pass {{ .Proto }}://{{ .Host }}{{ .Suffix }};
+		{{ if (exists (printf "/etc/nginx/htpasswd/%s" .Host)) }}
+		auth_basic	"Restricted {{ .Host }}";
+		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" .Host) }};
+		{{ end }}
+		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" .Host)) }}
+		include {{ printf "/etc/nginx/vhost.d/%s_location" .Host }};
+		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+		include /etc/nginx/vhost.d/default_location;
+		{{ end }}
+	}
 {{ end }}
 
 # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
@@ -72,23 +105,16 @@ server {
 
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
 
-{{ $host := trim $host }}
+{{ $hostParts := splitN (trim $host) "/" 2 }}
+{{ $host := index $hostParts 0 }}
+{{ $hasDefaultPath := eq (len $hostParts) 1 }}
 
-upstream {{ $host }} {
-{{ range $container := $containers }}
-	{{ $addrLen := len $container.Addresses }}
-	{{/* If only 1 port exposed, use that */}}
-	{{ if eq $addrLen 1 }}
-		{{ $address := index $container.Addresses 0 }}
-		{{ template "upstream" (dict "Container" $container "Address" $address) }}
-	{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
-	{{ else }}
-		{{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
-		{{ $address := where $container.Addresses "Port" $port | first }}
-		{{ template "upstream" (dict "Container" $container "Address" $address) }}
-	{{ end }}
+{{ if $hasDefaultPath }}
+{{ template "upstream-block" dict "Host" $host "Suffix" "" "Containers" $containers }}
+{{ else }}
+{{ $path := printf "/%s" (index $hostParts 1) }}
+{{ template "upstream-block" dict "Host" $host "Suffix" (printf "-%s" (sha1 $path)) "Containers" $containers }}
 {{ end }}
-}
 
 {{ $default_host := or ($.Env.DEFAULT_HOST) "" }}
 {{ $default_server := index (dict $host "" $default_host "default_server") $host }}
@@ -145,18 +171,12 @@ server {
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
 
-	location / {
-		proxy_pass {{ $proto }}://{{ $host }};
-		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
-		{{ end }}
-                {{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
-                include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
-                {{ else if (exists "/etc/nginx/vhost.d/default_location") }}
-                include /etc/nginx/vhost.d/default_location;
-                {{ end }}
-	}
+	{{ if $hasDefaultPath }}
+	{{ template "location" (dict "Path" "/" "Proto" $proto "Host" $host "Suffix" "" ) }}
+	{{ else }}
+	{{ $path := printf "/%s" (index $hostParts 1) }}
+	{{ template "location" (dict "Path" $path "Proto" $proto "Host" $host "Suffix" (printf "-%s" (sha1 $path)) ) }}
+	{{ end }}
 }
 {{ else }}
 
@@ -171,18 +191,12 @@ server {
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
 
-	location / {
-		proxy_pass {{ $proto }}://{{ $host }};
-		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
-		{{ end }}
-                {{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
-                include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
-                {{ else if (exists "/etc/nginx/vhost.d/default_location") }}
-                include /etc/nginx/vhost.d/default_location;
-                {{ end }}
-	}
+	{{ if $hasDefaultPath }}
+	{{ template "location" (dict "Path" "/" "Proto" $proto "Host" $host "Suffix" "" ) }}
+	{{ else }}
+	{{ $path := printf "/%s" (index $hostParts 1) }}
+	{{ template "location" (dict "Path" $path "Proto" $proto "Host" $host "Suffix" (printf "-%s" (sha1 $path)) ) }}
+	{{ end }}
 }
 
 {{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -72,6 +72,8 @@ server {
 
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
 
+{{ $host := trim $host }}
+
 upstream {{ $host }} {
 {{ range $container := $containers }}
 	{{ $addrLen := len $container.Addresses }}
@@ -92,7 +94,7 @@ upstream {{ $host }} {
 {{ $default_server := index (dict $host "" $default_host "default_server") $host }}
 
 {{/* Get the VIRTUAL_PROTO defined by containers w/ the same vhost, falling back to "http" */}}
-{{ $proto := or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http" }}
+{{ $proto := or (trim (first (groupByKeys $containers "Env.VIRTUAL_PROTO"))) "http" }}
 
 {{/* Get the first cert name defined by containers w/ the same vhost */}}
 {{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}
@@ -144,7 +146,7 @@ server {
 	{{ end }}
 
 	location / {
-		proxy_pass {{ trim $proto }}://{{ trim $host }};
+		proxy_pass {{ $proto }}://{{ $host }};
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
@@ -170,7 +172,7 @@ server {
 	{{ end }}
 
 	location / {
-		proxy_pass {{ trim $proto }}://{{ trim $host }};
+		proxy_pass {{ $proto }}://{{ $host }};
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};


### PR DESCRIPTION
I'm finally opening a PR to review my branch for supporting multiple paths with `VIRTUAL_PATH`. I think that some of the duplicated code could probably be made a bit more DRY, but this code seems like a good starting point for a discussion to me.

A couple things are happening in this patch.
1. Detect if `VIRTUAL_PATH` is being used within the containers with a shared `VIRTUAL_HOST`
2. If so, take the SHA-1 hash of the path and use it as a suffix for both the `upstream` name and the `proxy_pass` statement

In the event that `VIRTUAL_PATH` is not set for `/` within the context of a particular `VIRTUAL_HOST`, a 404 is returned. This should possibly be a 503 instead, but I didn't want to hold up the discussion of this patch any longer (it's been over a year since I first created this branch).

Known issues that might need to be addressed before merging:
1. Further consolidate duplicate code into the shared "location" template
2. Figure out if 503 should be returned for a missing `/` instead of 404
3. Handle the case where some containers within a `VIRTUAL_HOST` have `VIRTUAL_PATH` set but others do not

Fixes #33 
