### PR TITLE
VIRTUAL_HOST syntax to support multiple destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Currently this does not work with the new v2 syntax of docker-compose (due to no
 
 ### Multiple Ports
 
-If your container exposes multiple ports, nginx-proxy will default to the service running on port 80.  If you need to specify a different port, you can set a VIRTUAL_PORT env var to select a different one.  If your container only exposes one port and it has a VIRTUAL_HOST env var set, that port will be selected.
+If your container exposes multiple ports, nginx-proxy will default to the service running on port 80.  If you need to specify a different port, you can set a VIRTUAL_PORT env var to select a different one.  If your container only exposes one port and it has a VIRTUAL_HOST env var set, that port will be selected. Or you can try your hand at the Advanced VIRTUAL_HOST syntax.
 
   [1]: https://github.com/jwilder/docker-gen
   [2]: http://jasonwilder.com/blog/2014/03/25/automated-nginx-reverse-proxy-for-docker/
@@ -56,6 +56,22 @@ In this example, the `my-nginx-proxy` container will be connected to `my-network
 ### SSL Backends
 
 If you would like to connect to your backend using HTTPS instead of HTTP, set `VIRTUAL_PROTO=https` on the backend container.
+
+### Advanced VIRTUAL_HOST syntax
+
+Using the Advanced VIRTUAL_HOST syntax you can specify multiple host names to each go to their own backend port. Basically provides support for VIRTUAL_HOST, VIRTUAL_PORT, and VIRTUAL_PROTO all in one field.
+
+For example, given the following:
+
+```
+VIRTUAL_HOST=api.example.com=>http:80,api-admin.example.com=>http:8001,secure.example.com=>https:8443
+```
+
+This would yield 3 different server/upstream configurations...
+
+1. Requests for api.example.com would route to this container's port 80 via http
+2. Requests for api-admin.example.com would route to this containers port 8001 via http
+3. Requests for secure.example.com would route to this containers port 8443 via https
 
 ### Default Host
 
@@ -143,7 +159,7 @@ a 503.
 
 To serve traffic in both SSL and non-SSL modes without redirecting to SSL, you can include the
 environment variable `HTTPS_METHOD=noredirect` (the default is `HTTPS_METHOD=redirect`).  You can also
-disable the non-SSL site entirely with `HTTPS_METHOD=nohttp`. 
+disable the non-SSL site entirely with `HTTPS_METHOD=nohttp`.
 
 ### Basic Authentication Support
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -72,7 +72,13 @@ server {
 }
 {{ end }}
 
-{{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
+{{ range $opt, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
+{{ $parts := split $opt "=>"}}
+{{ $host := first $parts | trim }}
+{{ $dest := last $parts | trim }}
+{{ $destParts := split (when (ne $host $dest) $dest ":") ":" }}
+{{ $destProto := first $destParts }}
+{{ $destPort := last $destParts }}
 
 upstream {{ $host }} {
 {{ range $container := $containers }}
@@ -89,7 +95,7 @@ upstream {{ $host }} {
 					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 				{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
 				{{ else }}
-					{{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
+					{{ $port := coalesce $container.Env.VIRTUAL_PORT "80" | or $destPort }}
 					{{ $address := where $container.Addresses "Port" $port | first }}
 					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 				{{ end }}
@@ -103,7 +109,7 @@ upstream {{ $host }} {
 {{ $default_server := index (dict $host "" $default_host "default_server") $host }}
 
 {{/* Get the VIRTUAL_PROTO defined by containers w/ the same vhost, falling back to "http" */}}
-{{ $proto := or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http" }}
+{{ $proto := or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http" | or $destProto }}
 
 {{/* Get the HTTPS_METHOD defined by containers w/ the same vhost, falling back to "redirect" */}}
 {{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) "redirect" }}

--- a/test/multiple-ports.bats
+++ b/test/multiple-ports.bats
@@ -41,7 +41,7 @@ function setup {
 
 @test "[$TEST_FILE] VIRTUAL_HOST proxy syntax" {
 	# GIVEN
-	prepare_web_container bats-web-${TEST_FILE}-2 "80 90" -e VIRTUAL_HOST=web.bats=>http:80,web1.bats=>http:90
+	prepare_web_container bats-web-${TEST_FILE}-2 "80 90" -e VIRTUAL_HOST='web.bats=>http:80,web1.bats=>http:90'
 
 	# THEN
 	assert_response_is_from_port 80 web.bats

--- a/test/multiple-ports.bats
+++ b/test/multiple-ports.bats
@@ -39,6 +39,16 @@ function setup {
 }
 
 
+@test "[$TEST_FILE] VIRTUAL_HOST proxy syntax" {
+	# GIVEN
+	prepare_web_container bats-web-${TEST_FILE}-2 "80 90" -e VIRTUAL_HOST=web.bats=>http:80,web1.bats=>http:90
+
+	# THEN
+	assert_response_is_from_port 80 web.bats
+	assert_response_is_from_port 90 web1.bats
+}
+
+
 @test "[$TEST_FILE] single exposed port != 80" {
 	# GIVEN
 	prepare_web_container bats-web-${TEST_FILE}-3 1234 -e VIRTUAL_HOST=web.bats
@@ -58,7 +68,8 @@ function setup {
 # $1 port we are expecting an response from
 function assert_response_is_from_port {
 	local -r port=$1
-	run curl_container $SUT_CONTAINER /data --header "Host: web.bats"
+	local -r host=${2:-web.bats}
+	run curl_container $SUT_CONTAINER /data --header "Host: $host"
 	assert_output "answer from port $port"
 }
 


### PR DESCRIPTION
This request adds some additional functionality to handling the VIRTUAL_HOST environment variable. So in addition to the default functionality (ie `VIRUTAL_HOST=www.example.com`) you can also do something like this:

```
- VIRTUAL_HOST=admin.example.com=>https:8444,www.example.com=>http:8080,other.example.com
- VIRTUAL_PORT=8443
- VIRTUAL_PROTO=https
```

What this ultimately becomes is 3 upstream configurations (`admin.example.com`, `www.example.com`, and `other.example.com`). 
- The `admin.example.com` upstream would route to https://<container-ip>:8444
- The `www.example.com` upstream would route to http://<container-ip>:8080
- The `other.example.com` upstream would route to https://<container-ip>:8443
  - It will default to using todays logic if the protocol and port are not specified in the VIRTUAL_HOST syntax

This is useful for scenarios where you have an application that runs multiple interfaces on different ports. (my current use case is the WSO2 API Manager product, which has an admin interface on one port and client endpoints are on a different port). While in production we would probably run a separate instance for the admin (the other part would still be running idle) and a separate instance for the api endpoints and these would be scaled depending on the load. However, in dev environments, we only want the one container and running separate instances is kind of costly given that the WSO2 products each take about 500MB ram to run idle.
