### PR TITLE
Enable access_log customisation per virtual host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ RUN apt-get update \
  && apt-get clean \
  && rm -r /var/lib/apt/lists/*
 
-# Configure Nginx and apply fix for very long server names
+# Update default nginx.conf
+# - apply fix for very long server names
+# - delete access_log to allow for per-virtual host customisation in nginx.tmpl
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
- && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
+ && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g; /access_log/d' /etc/nginx/nginx.conf
 
 # Install Forego
 RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -35,7 +35,7 @@ log_format vhost '$host $remote_addr - $remote_user [$time_local] '
                  '"$request" $status $body_bytes_sent '
                  '"$http_referer" "$http_user_agent"';
 
-access_log off;
+access_log /dev/stdout vhost;
 
 {{ if (exists "/etc/nginx/proxy.conf") }}
 include /etc/nginx/proxy.conf;
@@ -54,7 +54,6 @@ proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
 	listen 80;
-	access_log /var/log/nginx/access.log vhost;
 	return 503;
 }
 
@@ -62,7 +61,6 @@ server {
 server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
 	listen 443 ssl http2;
-	access_log /var/log/nginx/access.log vhost;
 	return 503;
 
 	ssl_certificate /etc/nginx/certs/default.crt;
@@ -112,14 +110,12 @@ upstream {{ $host }} {
 server {
 	server_name {{ $host }};
 	listen 80 {{ $default_server }};
-	access_log /var/log/nginx/access.log vhost;
 	return 301 https://$host$request_uri;
 }
 
 server {
 	server_name {{ $host }};
 	listen 443 ssl http2 {{ $default_server }};
-	access_log /var/log/nginx/access.log vhost;
 
 	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 	ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
@@ -161,7 +157,6 @@ server {
 server {
 	server_name {{ $host }};
 	listen 80 {{ $default_server }};
-	access_log /var/log/nginx/access.log vhost;
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
 	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
@@ -187,7 +182,6 @@ server {
 server {
 	server_name {{ $host }};
 	listen 443 ssl http2 {{ $default_server }};
-	access_log /var/log/nginx/access.log vhost;
 	return 503;
 
 	ssl_certificate /etc/nginx/certs/default.crt;


### PR DESCRIPTION
Following on from #216 and #230 

Removing `access_log` from default nginx.conf enables per-virtual host logging configuration.

Is there any argument against modifying default nginx.conf in this way, considering it's already being done with the `server_names_hash_bucket_size`? If so, why is `server_names_hash_bucket_size` added in the Dockerfile instead of in `nginx.tmpl`?

Paging Dr @md5
