### PR TITLE
Only start nginx after dockergen is done

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-nginx: sleep 2; echo "Starting nginx..."; nginx
-dockergen: echo "Starting docker-gen..."; docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+nginx: while [ ! -f /etc/nginx/conf.d/dockergen.conf ]; do echo "Waiting for dockergen.conf to appear before starting nginx..."; sleep 1; done; echo "Starting nginx..."; nginx
+dockergen: echo "Starting docker-gen..."; docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/dockergen.conf

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-nginx: nginx
-dockergen: docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+nginx: sleep 2; echo "Starting nginx..."; nginx
+dockergen: echo "Starting docker-gen..."; docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This prevents nginx from failing when there is a custom nginx config that depends on things in the generated nginx config.

```
❯ docker-compose logs nginx-proxy
Attaching to smdevstack_nginx-proxy_1
nginx-proxy_1 | forego     | starting dockergen.1 on port 5000
nginx-proxy_1 | dockergen.1 | 2016/03/02 17:43:53 Generated '/etc/nginx/conf.d/default.conf' from 3 containers
nginx-proxy_1 | dockergen.1 | 2016/03/02 17:43:53 Running 'nginx -s reload || nginx'
```

Fixes: GH-378
