### PR TITLE
Optional passphrase support

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ hosts in use.  The certificate and keys should be named after the virtual host w
 
 #### Passphrase
 
-Optionally you can set passphrase file for each certificate by creating `.pw` file with passphrase in certs directory.
+Optionally you can set passphrase for certificate by creating `.pw` file with passphrase in `/path/to/certs` directory.
 For example `foo.bar.com.pw`.
 
 #### Diffie-Hellman Groups

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ hosts in use.  The certificate and keys should be named after the virtual host w
 `.key` extension.  For example, a container with `VIRTUAL_HOST=foo.bar.com` should have a
 `foo.bar.com.crt` and `foo.bar.com.key` file in the certs directory.
 
+#### Passphrase
+
+Optionally you can set passphrase file for each certificate by creating `.pw` file with passphrase in certs directory.
+For example `foo.bar.com.pw`.
+
 #### Diffie-Hellman Groups
 
 If you have Diffie-Hellman groups enabled, the files should be named after the virtual host with a

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -69,6 +69,9 @@ server {
 
 	ssl_certificate /etc/nginx/certs/default.crt;
 	ssl_certificate_key /etc/nginx/certs/default.key;
+	{{ if (exists "/etc/nginx/certs/default.pw") }}
+	ssl_password_file /etc/nginx/certs/default.pw;
+	{{ end }}
 }
 {{ end }}
 
@@ -149,6 +152,10 @@ server {
 	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
 	ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};
 
+	{{ if (exists (printf "/etc/nginx/certs/%s.pw" $cert)) }}
+	ssl_password_file {{ printf "/etc/nginx/certs/%s.pw" $cert }};
+	{{ end }}
+
 	{{ if (exists (printf "/etc/nginx/certs/%s.dhparam.pem" $cert)) }}
 	ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
 	{{ end }}
@@ -213,6 +220,9 @@ server {
 
 	ssl_certificate /etc/nginx/certs/default.crt;
 	ssl_certificate_key /etc/nginx/certs/default.key;
+	{{ if (exists "/etc/nginx/certs/default.pw") }}
+	ssl_password_file /etc/nginx/certs/default.pw;
+	{{ end }}
 }
 {{ end }}
 


### PR DESCRIPTION
This adds optional server parameter with passphrase to nginx configuration.
E.g. just add `.pw` file with your certificate passphrase to certs folder, e.g. `foo.bar.com.pw`
