### PR TITLE
Add env vars for custom template and nonstandard ports

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,4 +19,19 @@ if [ "$socketMissing" = 1 -a "$1" = forego -a "$2" = start -a "$3" = '-r' ]; the
 	exit 1
 fi
 
+# if a custom template has not been specified
+if [ -z "$CUSTOM_TEMPLATE" ]; then
+	# try to copy default config to another file if the other file doesn't yet exist
+	cp -n nginx.tmpl nginx_default.tmpl
+
+	# create symlink to default config file
+	ln -sf nginx_default.tmpl nginx.tmpl
+else
+	# try to copy default config to another file if the other file doesn't yet exist
+	cp -n nginx.tmpl nginx_default.tmpl
+
+	# create symlink to custom config file
+	ln -sf $CUSTOM_TEMPLATE nginx.tmpl
+fi
+
 exec "$@"

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -123,20 +123,26 @@ upstream {{ $host }} {
 
 {{ $is_https := (and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
+{{ $http_lport := or (first (groupByKeys $containers "Env.LISTEN_PORT_HTTP")) "80" }}
+{{ $https_lport := or (first (groupByKeys $containers "Env.LISTEN_PORT_HTTPS")) "443" }}
+
 {{ if $is_https }}
 
+{{ if ne $http_lport "None" }}
 {{ if eq $https_method "redirect" }}
 server {
 	server_name {{ $host }};
-	listen 80 {{ $default_server }};
+	listen {{ $http_lport }} {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 	return 301 https://$host$request_uri;
 }
 {{ end }}
+{{ end }}
 
+{{ if ne $https_lport "None" }}
 server {
 	server_name {{ $host }};
-	listen 443 ssl http2 {{ $default_server }};
+	listen {{ $https_lport }} ssl http2 {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 
 	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
@@ -174,14 +180,16 @@ server {
                 {{ end }}
 	}
 }
+{{ end }}
 
 {{ end }}
 
 {{ if or (not $is_https) (eq $https_method "noredirect") }}
 
+{{ if ne $http_lport "None" }}
 server {
 	server_name {{ $host }};
-	listen 80 {{ $default_server }};
+	listen {{ $http_lport }} {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
@@ -203,17 +211,20 @@ server {
                 {{ end }}
 	}
 }
+{{ end }}
 
+{{ if ne $https_lport "None" }}
 {{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
 	server_name {{ $host }};
-	listen 443 ssl http2 {{ $default_server }};
+	listen {{ $https_lport }} ssl http2 {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 	return 503;
 
 	ssl_certificate /etc/nginx/certs/default.crt;
 	ssl_certificate_key /etc/nginx/certs/default.key;
 }
+{{ end }}
 {{ end }}
 
 {{ end }}


### PR DESCRIPTION
The LISTEN_PORT_HTTP and LISTEN_PORT_HTTPS env variables can now be specified
on web-service containers in order to cause the proxy to listen on the
specified ports.  If you only want to allow listening on a port with SSL, these
variables can be set to the value "None" which causes them to not be used.  So,
for example, you could set LISTEN_PORT_HTTP=None in order to only proxy traffic
over a secure link.  If one or both of these env vars are omitted, the default
values of 80 and 443 will be used where omitted.  NOTE: these ports are
internal ports on the container.  If you set LISTEN_PORT_HTTPS=1234, and want
to make this accessible on the WAN at port 5555, then you will do something
like

```
docker run --expose 1234 -p 5555:1234 ...
```

Additionally, on the proxy container, a CUSTOM_TEMPLATE env variable can be
specified, which will instruct docker-gen to use the specified template instead
of the default template.  For example, if CUSTOM_TEMPLATE=/app/mytemplate, then
you will want to either copy your template to the container with 'docker cp',
or mount it from the host filesystem with something like

```
docker run -v /host/path:/app/mytemplate ...
```
