### PR TITLE
test config before reloading [untested]

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 nginx: nginx
-dockergen: docker-gen -watch -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+dockergen: docker-gen -watch -notify "nginx -t && nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
⚠️ This is an untested change for now ⚠️ 
### Question/discussion:

In general, wouldn't it be better to test the config before reloading nginx.
The expected outcome would be to have nginx still running, with your old config - instead of loosing connection through reverse-proxy to all your sites.
### Related to
- https://github.com/jwilder/nginx-proxy/issues/502
- https://github.com/jwilder/nginx-proxy/issues/438
