### PR TITLE
Add explanation in README on how to create a Basic Auth password file

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,11 @@ $ docker run -d -p 80:80 -p 443:443 \
     jwilder/nginx-proxy
 ```
 
-You'll need apache2-utils on the machine where you plan to create the htpasswd file. Follow these [instructions](http://httpd.apache.org/docs/2.2/programs/htpasswd.html)
+You'll need to create a password file for each virtualhost:
+
+```shell
+docker run --rm -ti m31271n/htpasswd <username> <password> > htpasswd
+```
 
 ### Custom Nginx Configuration
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ $ docker run -d -p 80:80 -p 443:443 \
 You'll need to create a password file for each virtualhost:
 
 ```shell
-docker run --rm -ti m31271n/htpasswd <username> <password> > htpasswd
+docker run --rm -ti m31271n/htpasswd <username> <password> > $VIRTUAL_HOST
 ```
 
 ### Custom Nginx Configuration


### PR DESCRIPTION
It's somehow similar to the explanation in [Native basic auth in Docker Registry deployment docs](https://docs.docker.com/registry/deploying/#/native-basic-auth).
