### PR TITLE
Do not reply to SSL requests with invalid hostnames

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -109,6 +109,10 @@ upstream {{ $host }} {
 {{/* Get the VIRTUAL_PROTO defined by containers w/ the same vhost, falling back to "http" */}}
 {{ $proto := or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http" }}
 
+{{/* Prepare hostnames to be converted in regex */}}
+{{ $http_host := replace $host "." "\\." -1 }}
+{{ $http_host := replace $http_host "," "|" -1 }}
+
 {{/* Get the HTTPS_METHOD defined by containers w/ the same vhost, falling back to "redirect" */}}
 {{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) "redirect" }}
 
@@ -142,6 +146,10 @@ server {
 	server_name {{ $host }};
 	listen 443 ssl http2 {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
+
+	if ( $http_host !~* ^({{ $http_host }}) ) {
+		return 444;
+	}
 
 	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 	ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
@@ -227,6 +235,10 @@ server {
 	listen 443 ssl http2 {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 	return 500;
+
+	if ( $http_host !~* ^({{ $http_host }}) ) {
+		return 444;
+	}
 
 	ssl_certificate /etc/nginx/certs/default.crt;
 	ssl_certificate_key /etc/nginx/certs/default.key;


### PR DESCRIPTION
If a client requests a domain with an invalid (or not present) hostname, nginx-proxy replies with a `503`, when in HTTP.
But when in HTTPS, it will just give you the first hostname in the configuration.

I find this unexpected for the client; it that might have mistyped the url and receives another different website as response. Also as a security concern against a specific type of attack, [Stackexchange discussion](http://security.stackexchange.com/q/55790/69147)

This PR is at protototype stage, there are no tests, and the response is 444 (that in nginx language means 'close the connection')

It's an acceptable PR? I would gladly learn how to make tests in bats, and update the PR
