### PR TITLE
Add useful debugging comments into the generated nginx config file

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -1,19 +1,32 @@
 {{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
-
+# -----------------------------------------------------------------------------
+# ENABLE_IPV6: {{ $.Env.ENABLE_IPV6 }}
+# DEFAULT_HOST: {{ $.Env.DEFAULT_HOST }}
+# VIRTUAL_PROTO: {{ $.Env.VIRTUAL_PROTO }}
+# HTTPS_METHOD: {{ $.Env.HTTPS_METHOD }}
+# CERT_NAME: {{ $.Env.CERT_NAME }}
+# networks: {{ json $CurrentContainer.Networks }}
+# -----------------------------------------------------------------------------
 {{ define "upstream" }}
+        # upstream(Container={{ .Container.Name }}, Address={{ json .Address }}, Network={{ .Network.Name }})
+        # Using swarm: {{ if .Container.Node.ID }}yes{{else}}no{{end}}
+        # Port published on host: {{ if .Address.HostPort }}yes{{else}}no{{end}}
 	{{ if .Address }}
 		{{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
 		{{ if and .Container.Node.ID .Address.HostPort }}
-			# {{ .Container.Node.Name }}/{{ .Container.Name }}
-			server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }};
+        server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }};  # {{ .Container.Node.Name }}/{{ .Container.Name }} (swarm mode and port published on host)
 		{{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
 		{{ else if .Network }}
-			# {{ .Container.Name }}
-			server {{ .Network.IP }}:{{ .Address.Port }};
+        server {{ .Network.IP }}:{{ .Address.Port }};  # {{ .Container.Name }}
+		{{ else }}
+		# unexpected case 1
+		# Container: {{ json .Container }}
 		{{ end }}
 	{{ else if .Network }}
-		# {{ .Container.Name }}
-		server {{ .Network.IP }} down;
+        server {{ .Network.IP }} down;  # {{ .Container.Name }}
+    {{ else }}
+		#### no .Address and no .Network provided to upstream template
+		# Container: {{ json .Container }}
 	{{ end }}
 {{ end }}
 
@@ -101,26 +114,34 @@ server {
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
 {{ $is_regexp := hasPrefix "~" $host }}
 {{ $upstream_name := when $is_regexp (sha1 $host) $host }}
-# {{ $host }}
+# ===================== {{ $host }}
 upstream {{ $upstream_name }} {
 {{ range $container := $containers }}
+        # ------------------------------------------------------
+        # container: {{ $container.Name }}
+        # VIRTUAL_HOST: {{ $container.Env.VIRTUAL_HOST }}
+        # VIRTUAL_PORT: {{ $container.Env.VIRTUAL_PORT }}
 	{{ $addrLen := len $container.Addresses }}
 
 	{{ range $knownNetwork := $CurrentContainer.Networks }}
 		{{ range $containerNetwork := $container.Networks }}
 			{{ if eq $knownNetwork.Name $containerNetwork.Name }}
-				## Can be connect with "{{ $containerNetwork.Name }}" network
+        # Can be connect with "{{ $containerNetwork.Name }}" network
 
 				{{/* If only 1 port exposed, use that */}}
 				{{ if eq $addrLen 1 }}
+        # only 1 port exposed
 					{{ $address := index $container.Addresses 0 }}
 					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 				{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
 				{{ else }}
+        # multiple ports exposed: {{ json $container.Addresses }}
 					{{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
 					{{ $address := where $container.Addresses "Port" $port | first }}
 					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 				{{ end }}
+			{{ else }}
+        # Cannot be connect with "{{ $containerNetwork.Name }}" network
 			{{ end }}
 		{{ end }}
 	{{ end }}
@@ -152,8 +173,10 @@ upstream {{ $upstream_name }} {
 {{ $is_https := (and (ne $https_method "nohttps") (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
 {{ if $is_https }}
+# start if $is_https
 
 {{ if eq $https_method "redirect" }}
+# HTTPS_METHOD=redirect start
 server {
 	server_name {{ $host }};
 	listen 80 {{ $default_server }};
@@ -163,6 +186,8 @@ server {
 	access_log /var/log/nginx/access.log vhost;
 	return 301 https://$host$request_uri;
 }
+
+# HTTPS_METHOD=redirect end
 {{ end }}
 
 server {
@@ -189,7 +214,7 @@ server {
 	{{ end }}
 
 	{{ if (ne $https_method "noredirect") }}
-	add_header Strict-Transport-Security "max-age=31536000";
+	add_header Strict-Transport-Security "max-age=31536000";  # because HTTPS_METHOD=noredirect
 	{{ end }}
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
@@ -217,11 +242,13 @@ server {
 	}
 }
 
+# end if $is_https
 {{ end }}
 
 {{ if or (not $is_https) (eq $https_method "noredirect") }}
 
 server {
+	# not https or HTTPS_METHOD=noredirect
 	server_name {{ $host }};
 	listen 80 {{ $default_server }};
 	{{ if $enable_ipv6 }}
@@ -256,6 +283,7 @@ server {
 
 {{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
+	# not https and /etc/nginx/certs/default.crt and /etc/nginx/certs/default.key exist
 	server_name {{ $host }};
 	listen 443 ssl http2 {{ $default_server }};
 	{{ if $enable_ipv6 }}
@@ -268,6 +296,7 @@ server {
 	ssl_certificate_key /etc/nginx/certs/default.key;
 }
 {{ end }}
-
 {{ end }}
+# ===================== end {{ $host }}
+
 {{ end }}


### PR DESCRIPTION
In the issue tracker, as many share their generated nginx config without context, it is impossible to get a glimpse of what could be wrong without starting a conversation asking the OP for more details/context.

With this changes, the generated nginx config file will contain useful comments about environment variables, networks that were set at the time of generation.

Here's an example of generated default.conf file:

    # -----------------------------------------------------------------------------
    # ENABLE_IPV6: <no value>
    # DEFAULT_HOST: <no value>
    # VIRTUAL_PROTO: <no value>
    # HTTPS_METHOD: <no value>
    # CERT_NAME: <no value>
    # networks: [{"IP":"172.17.0.3","Name":"bridge","Gateway":"172.17.0.1","EndpointID":"97bee4eb661a72764cdab741abf294b4f9c1c31a6cfe5f5e1c3569cbe1554995","IPv6Gateway":"2001:db8:1::1","GlobalIPv6Address":"2001:db8:1::242:ac11:3","MacAddress":"02:42:ac:11:00:03","GlobalIPv6PrefixLen":64,"IPPrefixLen":16}]
    # -----------------------------------------------------------------------------
    # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
    # scheme used to connect to this server
    map $http_x_forwarded_proto $proxy_x_forwarded_proto {
      default $http_x_forwarded_proto;
      ''      $scheme;
    }
    # If we receive X-Forwarded-Port, pass it through; otherwise, pass along the
    # server port the client connected to
    map $http_x_forwarded_port $proxy_x_forwarded_port {
      default $http_x_forwarded_port;
      ''      $server_port;
    }
    # If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
    # Connection header that may have been passed to this server
    map $http_upgrade $proxy_connection {
      default upgrade;
      '' close;
    }
    # Set appropriate X-Forwarded-Ssl header
    map $scheme $proxy_x_forwarded_ssl {
      default off;
      https on;
    }
    gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
    log_format vhost '$host $remote_addr - $remote_user [$time_local] '
                     '"$request" $status $body_bytes_sent '
                     '"$http_referer" "$http_user_agent"';
    access_log off;
    # HTTP 1.1 support
    proxy_http_version 1.1;
    proxy_buffering off;
    proxy_set_header Host $http_host;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection $proxy_connection;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
    proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
    proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
    # Mitigate httpoxy attack (see README for details)
    proxy_set_header Proxy "";
    server {
      server_name _; # This is just an invalid value which will never trigger on a real hostname.
      listen 80;
      access_log /var/log/nginx/access.log vhost;
      return 503;
    }
    # ===================== web.nginx-proxy.tld
    upstream web.nginx-proxy.tld {
            # ------------------------------------------------------
            # container: testmultipleports_web_1
            # VIRTUAL_HOST: web.nginx-proxy.tld
            # VIRTUAL_PORT: 90
            # Can be connect with "bridge" network
            # multiple ports exposed: [{"IP":"172.17.0.2","IP6LinkLocal":"","IP6Global":"2001:db8:1::242:ac11:2","Port":"80","HostPort":"","Proto":"tcp","HostIP":""},{"IP":"172.17.0.2","IP6LinkLocal":"","IP6Global":"2001:db8:1::242:ac11:2","Port":"90","HostPort":"","Proto":"tcp","HostIP":""}]
            # upstream(Container=testmultipleports_web_1, Address={"IP":"172.17.0.2","IP6LinkLocal":"","IP6Global":"2001:db8:1::242:ac11:2","Port":"90","HostPort":"","Proto":"tcp","HostIP":""}, Network=bridge)
            # Using swarm: no
            # Port published on host: no
            server 172.17.0.2:90;  # testmultipleports_web_1
    }
    server {
      # not https or HTTPS_METHOD=noredirect
      server_name web.nginx-proxy.tld;
      listen 80 ;
      access_log /var/log/nginx/access.log vhost;
      location / {
        proxy_pass http://web.nginx-proxy.tld;
      }
    }
    # ===================== end web.nginx-proxy.tld
    