### PR TITLE
Remove container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ version: '2'
 services:
   nginx-proxy:
     image: jwilder/nginx-proxy
-    container_name: nginx-proxy
     ports:
       - "80:80"
     volumes:
@@ -50,7 +49,6 @@ services:
 
   whoami:
     image: jwilder/whoami
-    container_name: whoami
     environment:
       - VIRTUAL_HOST=whoami.local
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2'
 services:
   nginx-proxy:
     image: jwilder/nginx-proxy
-    container_name: nginx-proxy
     ports:
       - "80:80"
     volumes:


### PR DESCRIPTION
Remove references to `container_name` as this causes causes conflicts when copied and pasted and used on multiple projects.