### PR TITLE
Adding support for armhf

### DIFF
--- a/Dockerfile.alpine-armhf
+++ b/Dockerfile.alpine-armhf
@@ -1,0 +1,33 @@
+FROM armhf/alpine:latest
+MAINTAINER BrainGamer
+
+ENV DOCKER_GEN_VERSION 0.7.3
+
+# Install Forego
+ADD https://github.com/djmaze/armhf-forego/releases/download/v0.16.1/forego /usr/local/bin/forego
+
+# Get everything ready
+RUN apk add --update \
+  nginx bash wget ca-certificates && \
+  mkdir -p /run/nginx && \
+  chmod u+x /usr/local/bin/forego && \
+  wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-armhf-$DOCKER_GEN_VERSION.tar.gz && \
+  tar -C /usr/local/bin -xvzf docker-gen-linux-armhf-$DOCKER_GEN_VERSION.tar.gz && \
+  rm /docker-gen-linux-armhf-$DOCKER_GEN_VERSION.tar.gz && \
+  rm -rf /var/lib/nginx/html && \
+  apk del wget ca-certificates && \
+  rm -rf /var/cache/apk/*
+  
+# Configure Nginx and apply fix for very long server names
+COPY ./nginx.conf /etc/nginx/nginx.conf
+#RUN sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
+
+COPY . /app/
+WORKDIR /app/
+
+ENV DOCKER_HOST unix:///tmp/docker.sock
+
+VOLUME ["/etc/nginx/certs"]
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["forego", "start", "-r"]

--- a/Dockerfile.alpine-armhf
+++ b/Dockerfile.alpine-armhf
@@ -19,8 +19,8 @@ RUN apk add --update \
   rm -rf /var/cache/apk/*
   
 # Configure Nginx and apply fix for very long server names
-COPY ./nginx.conf /etc/nginx/nginx.conf
-RUN sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
+ && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
 
 COPY . /app/
 WORKDIR /app/

--- a/Dockerfile.alpine-armhf
+++ b/Dockerfile.alpine-armhf
@@ -20,7 +20,7 @@ RUN apk add --update \
   
 # Configure Nginx and apply fix for very long server names
 COPY ./nginx.conf /etc/nginx/nginx.conf
-#RUN sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
+RUN sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
 
 COPY . /app/
 WORKDIR /app/


### PR DESCRIPTION
I got this nginx-proxy working with this dockerfile some time ago and I thought it would be nice if it is in the main repo and not in a fork somewhere spread out ;) 

This image worked fine for me so far and I never had issues at all.
It is based on alpine (for armhf) so it is pretty lightweight.