### PR TITLE
fix: fix 'create-server-certificate' by using a Dockerfile

### DIFF
--- a/test/certs/Dockerfile
+++ b/test/certs/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:1.13
+LABEL maintainer="Jason Wilder mail@jasonwilder.com"
+
+# Install `openssl` and clean up the `apt` cache.
+RUN apt update \
+ && apt install openssl -y --no-install-recommends \
+ && apt-get clean \
+ && rm -r /var/lib/apt/lists/*

--- a/test/certs/create_server_certificate.sh
+++ b/test/certs/create_server_certificate.sh
@@ -19,12 +19,18 @@ else
 	ALTERNATE_DOMAINS="DNS:$( echo "$@" | sed 's/ /,DNS:/g')"
 fi
 
+###############################################################################
+# Create a `nginx-openssl` image (`nginx` image with `openssl` installed)
+###############################################################################
+
+NGINX_OPENSSL_IMAGE="nginx-proxy/nginx-openssl"
+docker build . -t "$NGINX_OPENSSL_IMAGE"
 
 ###############################################################################
 # Create a nginx container (which conveniently provides the `openssl` command)
 ###############################################################################
 
-CONTAINER=$(docker run -d -v $DIR:/work -w /work -e SAN="$ALTERNATE_DOMAINS" nginx:1.13)
+CONTAINER=$(docker run -d -v $DIR:/work -w /work -e SAN="$ALTERNATE_DOMAINS" "$NGINX_OPENSSL_IMAGE")
 # Configure openssl
 docker exec $CONTAINER bash -c '
 	mkdir -p /ca/{certs,crl,private,newcerts} 2>/dev/null


### PR DESCRIPTION
`openssl` was removed from the `docker` `nginx` image (https://github.com/nginxinc/docker-nginx/issues/182); `nginx:1.13` is affected.
```
docker run -it nginx:1.13 openssl
docker: Error response from daemon: oci runtime error: container_linux.go:262: starting container process caused "exec: \"openssl\": executable file not found in $PATH".
```

Command: `./create_server_certificate.sh "*.example.com"`

Errors:
```
Create a host key: /Users/matteocng/web/nginx-proxy/test/certs/*.example.com.key
rpc error: code = 2 desc = oci runtime error: exec failed: container_linux.go:262: starting container process caused "exec: \"openssl\": executable file not found in $PATH"

Create a host certificate signing request
rpc error: code = 2 desc = oci runtime error: exec failed: container_linux.go:262: starting container process caused "exec: \"openssl\": executable file not found in $PATH"

ERROR: failed to generate server certificate signing request
```

This PR introduces a simple `Dockerfile` for an `nginx` image with `openssl`, and modifies `create_server_certificate.sh`to build it and use it.