### PR TITLE
Add in vhost https bypass

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -175,7 +175,18 @@ server {
 	listen [::]:80 {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
-	return 301 https://$host$request_uri;
+	
+	{{/* Add in includes to allow vhost includes*/}}
+	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+	{{ else if (exists "/etc/nginx/vhost.d/default") }}
+	include /etc/nginx/vhost.d/default;
+	{{ end }}
+	
+	{{/* If none of the locations match in the vhosts then redirect to the https page */}}
+	location {
+		return 301 https://$host$request_uri;
+	}
 }
 {{ end }}
 


### PR DESCRIPTION
Allow locations that are served via vhost includes to bypass the https redirect.

This allows the lets encrypt challenges to return successfully during initial certificate creation (they'll always be http since https hasn't been setup yet)