### PR TITLE
Upd: Boost worker_connections from 1024 to 10240.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update \
 
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
- && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf
+ && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
+ && sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf
 
 # Install Forego
 ADD https://github.com/jwilder/forego/releases/download/v0.16.1/forego /usr/local/bin/forego

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,7 +9,8 @@ RUN apk add --no-cache --virtual .run-deps \
 
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
- && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf
+ && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
+ && sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf
 
 # Install Forego
 ADD https://github.com/jwilder/forego/releases/download/v0.16.1/forego /usr/local/bin/forego


### PR DESCRIPTION
> It's very common to have thousands of clients, especially for a public website. I stopped counting the amount of websites I've seen went down because of the low defaults.

[source](https://serverfault.com/questions/787919/optimal-value-for-nginx-worker-connections)