### PR TITLE
Support local timezone on alpine image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,6 +6,8 @@ RUN apk add --no-cache --virtual .run-deps \
     ca-certificates bash wget openssl \
     && update-ca-certificates
 
+# Install timezone
+RUN apk add --update --no-cache tzdata
 
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '2'
+
 services:
   nginx-proxy:
     image: jwilder/nginx-proxy
-    container_name: nginx-proxy
     ports:
       - "80:80"
     volumes:

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -54,9 +54,15 @@ map $scheme $proxy_x_forwarded_ssl {
 
 gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
+{{ if $.Env.TIMEFMT_ISO }}
+log_format vhost '$host $remote_addr - $remote_user [$time_iso8601] '
+                 '"$request" $status $body_bytes_sent '
+                 '"$http_referer" "$http_user_agent"';
+{{ else }}
 log_format vhost '$host $remote_addr - $remote_user [$time_local] '
                  '"$request" $status $body_bytes_sent '
                  '"$http_referer" "$http_user_agent"';
+{{ end }}
 
 access_log off;
 


### PR DESCRIPTION
It works both jwilder/nginx-proxy:latest, jwilder/nginx-proxy:alpine with timezone environment

```sh
version: '2'

services:
  nginx-proxy:
    image: jwilder/nginx-proxy
    ports:
      - "80:80"
    volumes:
      - /var/run/docker.sock:/tmp/docker.sock:ro
    environment:
      - TZ=Asia/Seoul

  whoami:
    image: jwilder/whoami
    environment:
      - VIRTUAL_HOST=whoami.local
```

display in local time (Asia/Seoul, +09:00) not UTC

![snap1](https://user-images.githubusercontent.com/6913728/32695418-9ca12476-c79e-11e7-9560-e1296bf5a763.png)
