### PR TITLE
Use bridge as network_mode in examples

### DIFF
--- a/docker-compose-separate-containers.yml
+++ b/docker-compose-separate-containers.yml
@@ -7,6 +7,7 @@ services:
       - "80:80"
     volumes:
       - /etc/nginx/conf.d
+    network_mode: "bridge"
 
   dockergen:
     image: jwilder/docker-gen
@@ -16,8 +17,10 @@ services:
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl
+    network_mode: "bridge"
 
   whoami:
     image: jwilder/whoami
     environment:
       - VIRTUAL_HOST=whoami.local
+    network_mode: "bridge"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,10 @@ services:
       - "80:80"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
+    network_mode: "bridge"
 
   whoami:
     image: jwilder/whoami
     environment:
       - VIRTUAL_HOST=whoami.local
+    network_mode: "bridge"


### PR DESCRIPTION
See: #729 

Connecting dependent projects' to the correct Docker network has a common gotcha when using nginx-proxy. Setting `network_mode: "bridge"` in the default `docker-compose.yml` should help to address this.