### PR TITLE
Add ARM builds for running on Raspberry PI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ circle.yml
 Makefile
 README.md
 test
+Dockerfile*

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,17 @@ RUN apt-get update \
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf
 
+ENV DOCKER_PLATFORM amd64
+
 # Install Forego
-ADD https://github.com/jwilder/forego/releases/download/v0.16.1/forego /usr/local/bin/forego
-RUN chmod u+x /usr/local/bin/forego
+RUN wget -q -O - https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-$DOCKER_PLATFORM.tgz \
+  | tar -C /usr/local/bin -xvz \
+ && chmod u+x /usr/local/bin/forego
 
 ENV DOCKER_GEN_VERSION 0.7.3
 
-RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
- && tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
- && rm /docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
+RUN wget -q -O - https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-$DOCKER_PLATFORM-$DOCKER_GEN_VERSION.tar.gz \
+  | tar -C /usr/local/bin -xvz
 
 COPY network_internal.conf /etc/nginx/
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -11,15 +11,17 @@ RUN apk add --no-cache --virtual .run-deps \
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf
 
+ENV DOCKER_PLATFORM amd64
+
 # Install Forego
-ADD https://github.com/jwilder/forego/releases/download/v0.16.1/forego /usr/local/bin/forego
-RUN chmod u+x /usr/local/bin/forego
+RUN wget -q -O - https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-$DOCKER_PLATFORM.tgz \
+  | tar -C /usr/local/bin -xvz \
+ && chmod u+x /usr/local/bin/forego
 
 ENV DOCKER_GEN_VERSION 0.7.3
 
-RUN wget --quiet https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
- && tar -C /usr/local/bin -xvzf docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
- && rm /docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
+RUN wget -q -O - https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-alpine-linux-$DOCKER_PLATFORM-$DOCKER_GEN_VERSION.tar.gz \
+  | tar -C /usr/local/bin -xvz
 
 COPY . /app/
 WORKDIR /app/

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,0 +1,40 @@
+FROM arm32v7/nginx:1.13
+LABEL maintainer="Jason Wilder mail@jasonwilder.com"
+
+# Install wget and install/updates certificates
+RUN apt-get update \
+ && apt-get install -y -q --no-install-recommends \
+    ca-certificates \
+    wget \
+ && apt-get clean \
+ && rm -r /var/lib/apt/lists/*
+
+
+# Configure Nginx and apply fix for very long server names
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
+ && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf
+
+ENV DOCKER_PLATFORM arm
+
+# Install Forego
+RUN wget -q -O - https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-$DOCKER_PLATFORM.tgz \
+  | tar -C /usr/local/bin -xvz \
+ && chmod u+x /usr/local/bin/forego
+
+ENV DOCKER_GEN_VERSION 0.7.3
+ENV DOCKER_PLATFORM armel
+
+RUN wget -q -O - https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-$DOCKER_PLATFORM-$DOCKER_GEN_VERSION.tar.gz \
+  | tar -C /usr/local/bin -xvz
+
+COPY network_internal.conf /etc/nginx/
+
+COPY . /app/
+WORKDIR /app/
+
+ENV DOCKER_HOST unix:///tmp/docker.sock
+
+VOLUME ["/etc/nginx/certs", "/etc/nginx/dhparam"]
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["forego", "start", "-r"]


### PR DESCRIPTION
This PR does two things.

1. Use `ddollar/forego` as arm binaries available and builds with latest Golang 1.9.
1. Adds `Dockerfile.arm` for building ARM container images for use on a raspberry pi