### PR TITLE
feat: Add rpi version

### DIFF
--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -1,0 +1,44 @@
+FROM arm32v7/nginx:1.13
+LABEL maintainer="Jason Wilder mail@jasonwilder.com"
+
+# Install wget and install/updates certificates
+RUN apt-get update \
+ && apt-get install -y -q --no-install-recommends \
+    ca-certificates \
+    wget \
+    golang-go \
+    git \
+ && apt-get clean \
+ && rm -r /var/lib/apt/lists/*
+
+
+# Configure Nginx and apply fix for very long server names
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
+ && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf
+
+# Install Forego
+RUN export GOPATH="/go" \
+ && go get -u github.com/ddollar/forego
+ 
+ENV PATH=$PATH:/go/bin
+
+# Remove go a git
+RUN apt-get purge -yq golang-go git
+
+ENV ARCH_VERSION armhf
+ENV DOCKER_GEN_VERSION 0.7.3
+
+RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-$ARCH_VERSION-$DOCKER_GEN_VERSION.tar.gz \
+ && tar -C /usr/local/bin -xvzf docker-gen-linux-$ARCH_VERSION-$DOCKER_GEN_VERSION.tar.gz \
+ && rm /docker-gen-linux-$ARCH_VERSION-$DOCKER_GEN_VERSION.tar.gz
+COPY network_internal.conf /etc/nginx/
+
+COPY . /app/
+WORKDIR /app/
+
+ENV DOCKER_HOST unix:///tmp/docker.sock
+
+VOLUME ["/etc/nginx/certs", "/etc/nginx/dhparam"]
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["forego", "start", "-r"]


### PR DESCRIPTION
This PR adds a dockerfile version for rpi from arm32v7 nginx image
It's also use a new ENV var (ARCH_VERSION=armhf) to download correct version of docker-gen and build forego from source in order to build it in the correct architecture.

Related with #1017