### PR TITLE
nginx.tmpl: Adding possibility for default htpasswd file

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ $ docker run -d -p 80:80 -p 443:443 \
     jwilder/nginx-proxy
 ```
 
+It is also possible to create the default htpasswd file /etc/nginx/htpasswd/default that is used when no file named after $VIRTUAL_HOST is present. This can be used when all virtual host should have the same Basic Authentication anyway or as an extra security measure to make sure that no service is exposed to the wild internet without authentication even if there is a error in the configuration and/or file naming.
+
 You'll need apache2-utils on the machine where you plan to create the htpasswd file. Follow these [instructions](http://httpd.apache.org/docs/2.2/programs/htpasswd.html)
 
 ### Custom Nginx Configuration

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -287,6 +287,9 @@ server {
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+		{{ else if (exists "/etc/nginx/htpasswd/default") }}
+		auth_basic  "Restricted {{ $host }}";
+		auth_basic_user_file    /etc/nginx/htpasswd/default;
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
 		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
@@ -330,9 +333,13 @@ server {
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}
+
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+		{{ else if (exists "/etc/nginx/htpasswd/default") }}
+		auth_basic  "Restricted {{ $host }}";
+		auth_basic_user_file    /etc/nginx/htpasswd/default;
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
 		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};


### PR DESCRIPTION
Adding the possibility for default htpasswd file (`/etc/nginx/htpasswd/default`) that is used when no file named after $VIRTUAL_HOST is present.

This can be used when all virtual host should have the same Basic Authentication anyway.

Or as an extra security measure to make sure that no service is exposed to the wild internet without authentication even if there is a error in the configuration and/or file naming.

If there are several services under different subdomains it isn't easy to get this right in the moment. Of course you could work with symbolic links, but this also gets messy very fast. And especially while you try out things and polish your configs and services it happens easily that a service is exposed to the wild without you noticing at first (hopefully only at first).