### PR TITLE
Suffix upstream names to prevent confusion with FQDNs

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -172,7 +172,7 @@ server {
 
 {{ $host := trim $host }}
 {{ $is_regexp := hasPrefix "~" $host }}
-{{ $upstream_name := when $is_regexp (sha1 $host) $host }}
+{{ $upstream_name := (print (when $is_regexp (sha1 $host) $host) "-upstream") }}
 
 # {{ $host }}
 upstream {{ $upstream_name }} {


### PR DESCRIPTION
This fixes #1162