### PR TITLE
allow one .htpasswd file for all VIRTUAL_HOST’s

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -186,7 +186,7 @@ upstream {{ $upstream_name }} {
 {{/* Use the cert specified on the container or fallback to the best vhost match */}}
 {{ $cert := (coalesce $certName $vhostCert) }}
 
-{{ $is_https := (and (ne $https_method "nohttps") (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
+{{ $is_https := (and (ne $https_method "nohttps") (ne $cert "") (exists (printf "/etc/nginx/certs/fullchain.pem" $cert)) (exists (printf "/etc/nginx/certs/privkey.pem" $cert))) }}
 
 {{ if $is_https }}
 
@@ -248,9 +248,9 @@ server {
 	ssl_session_timeout 5m;
 	ssl_session_cache shared:SSL:50m;
 	ssl_session_tickets off;
-
-	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
-	ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};
+	
+	ssl_certificate /etc/nginx/certs/fullchain.pem;
+	ssl_certificate_key /etc/nginx/certs/privkey.pem;
 
 	{{ if (exists (printf "/etc/nginx/certs/%s.dhparam.pem" $cert)) }}
 	ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -284,10 +284,13 @@ server {
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}
 
-		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
-		{{ end }}
+        {{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+            auth_basic	"Restricted {{ $host }}";
+            auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+        {{ else if (exists ("/etc/nginx/htpasswd/.htpasswd")) }}
+            auth_basic	"Restricted {{ $host }}";
+            auth_basic_user_file	{{ "/etc/nginx/htpasswd/.htpasswd" }};
+        {{ end }}
 		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
 		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
 		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
@@ -331,9 +334,12 @@ server {
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
-		{{ end }}
+            auth_basic	"Restricted {{ $host }}";
+            auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+        {{ else if (exists ("/etc/nginx/htpasswd/.htpasswd")) }}
+            auth_basic	"Restricted {{ $host }}";
+            auth_basic_user_file	{{ "/etc/nginx/htpasswd/.htpasswd" }};
+        {{ end }}
 		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
 		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
 		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}


### PR DESCRIPTION
I use the nginx-proxy for my dev-Server. So I need a http-password for every vHost. To keep it simple I added the functionality to add a single `/etc/nginx/htpasswd/.htpasswd` file for all vHosts. This file can be overwritten by a specific File per vHost `/etc/nginx/htpasswd/$VIRTUAL_HOST`.