### PR TITLE
disable basic authentication for HTTP OPTIONS for CORS

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -285,8 +285,10 @@ server {
 		{{ end }}
 
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+		limit_except OPTIONS {
+		  auth_basic	"Restricted {{ $host }}";
+		  auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+		}
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
 		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};


### PR DESCRIPTION
This is to make CORS to work together with basic authentication. OPTIONS should not be restricted as browsers don't send the auth bearer for pre-flight requests

