### PR TITLE
Allow complete override of location blocks

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -76,38 +76,46 @@
 {{- end }}
 
 {{- define "location" }}
+    {{- $override := printf "/etc/nginx/vhost.d/%s_%s_location_override" .Host (sha1 .Path) }}
+    {{- if and (eq .Path "/") (not (exists $override)) }}
+        {{- $override = printf "/etc/nginx/vhost.d/%s_location_override" .Host }}
+    {{- end }}
+    {{- if exists $override }}
+    include {{ $override }};
+    {{- else }}
     location {{ .Path }} {
-    {{- if eq .NetworkTag "internal" }}
+        {{- if eq .NetworkTag "internal" }}
         # Only allow traffic from internal clients
         include /etc/nginx/network_internal.conf;
-    {{- end }}
+        {{- end }}
 
-    {{- if eq .Proto "uwsgi" }}
+        {{- if eq .Proto "uwsgi" }}
         include uwsgi_params;
         uwsgi_pass {{ trim .Proto }}://{{ trim .Upstream }};
-    {{- else if eq .Proto "fastcgi" }}
+        {{- else if eq .Proto "fastcgi" }}
         root {{ trim .VhostRoot }};
         include fastcgi_params;
         fastcgi_pass {{ trim .Upstream }};
-    {{- else if eq .Proto "grpc" }}
+        {{- else if eq .Proto "grpc" }}
         grpc_pass {{ trim .Proto }}://{{ trim .Upstream }};
-    {{- else }}
+        {{- else }}
         proxy_pass {{ trim .Proto }}://{{ trim .Upstream }}{{ trim .Dest }};
-    {{- end }}
+        {{- end }}
 
-    {{- if (exists (printf "/etc/nginx/htpasswd/%s" .Host)) }}
+        {{- if (exists (printf "/etc/nginx/htpasswd/%s" .Host)) }}
         auth_basic "Restricted {{ .Host }}";
         auth_basic_user_file {{ (printf "/etc/nginx/htpasswd/%s" .Host) }};
-    {{- end }}
+        {{- end }}
 
-    {{- if (exists (printf "/etc/nginx/vhost.d/%s_%s_location" .Host (sha1 .Path) )) }}
+        {{- if (exists (printf "/etc/nginx/vhost.d/%s_%s_location" .Host (sha1 .Path) )) }}
         include {{ printf "/etc/nginx/vhost.d/%s_%s_location" .Host (sha1 .Path) }};
-    {{- else if (exists (printf "/etc/nginx/vhost.d/%s_location" .Host)) }}
+        {{- else if (exists (printf "/etc/nginx/vhost.d/%s_location" .Host)) }}
         include {{ printf "/etc/nginx/vhost.d/%s_location" .Host}};
-    {{- else if (exists "/etc/nginx/vhost.d/default_location") }}
+        {{- else if (exists "/etc/nginx/vhost.d/default_location") }}
         include /etc/nginx/vhost.d/default_location;
-    {{- end }}
+        {{- end }}
     }
+    {{- end }}
 {{- end }}
 
 {{- define "upstream" }}

--- a/test/test_location-override.py
+++ b/test/test_location-override.py
@@ -1,0 +1,39 @@
+def test_explicit_root_nohash(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://explicit-root-nohash.nginx-proxy.test/port")
+    assert r.status_code == 418
+    r = nginxproxy.get("http://explicit-root-nohash.nginx-proxy.test/foo/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 82\n"
+
+def test_explicit_root_hash(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://explicit-root-hash.nginx-proxy.test/port")
+    assert r.status_code == 418
+    r = nginxproxy.get("http://explicit-root-hash.nginx-proxy.test/foo/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 82\n"
+
+def test_explicit_root_hash_and_nohash(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://explicit-root-hash-and-nohash.nginx-proxy.test/port")
+    assert r.status_code == 418
+    r = nginxproxy.get("http://explicit-root-hash-and-nohash.nginx-proxy.test/foo/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 82\n"
+
+def test_explicit_nonroot(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://explicit-nonroot.nginx-proxy.test/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 81\n"
+    r = nginxproxy.get("http://explicit-nonroot.nginx-proxy.test/foo/port")
+    assert r.status_code == 418
+
+def test_implicit_root_nohash(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://implicit-root-nohash.nginx-proxy.test/port")
+    assert r.status_code == 418
+
+def test_implicit_root_hash(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://implicit-root-hash.nginx-proxy.test/port")
+    assert r.status_code == 418
+
+def test_implicit_root_hash_and_nohash(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://implicit-root-hash-and-nohash.nginx-proxy.test/port")
+    assert r.status_code == 418

--- a/test/test_location-override.vhost.d/explicit-nonroot.nginx-proxy.test_8d960560c82f4e6c8b1b0f03eb30a1afd00e5696_location_override
+++ b/test/test_location-override.vhost.d/explicit-nonroot.nginx-proxy.test_8d960560c82f4e6c8b1b0f03eb30a1afd00e5696_location_override
@@ -1,0 +1,3 @@
+location /foo/ {
+    return 418;
+}

--- a/test/test_location-override.vhost.d/explicit-root-hash-and-nohash.nginx-proxy.test_42099b4af021e53fd8fd4e056c2568d7c2e3ffa8_location_override
+++ b/test/test_location-override.vhost.d/explicit-root-hash-and-nohash.nginx-proxy.test_42099b4af021e53fd8fd4e056c2568d7c2e3ffa8_location_override
@@ -1,0 +1,4 @@
+# This file should trump the file without the hash.
+location / {
+    return 418;
+}

--- a/test/test_location-override.vhost.d/explicit-root-hash-and-nohash.nginx-proxy.test_location_override
+++ b/test/test_location-override.vhost.d/explicit-root-hash-and-nohash.nginx-proxy.test_location_override
@@ -1,0 +1,4 @@
+# The file with the hash should trump this file.
+location / {
+    return 503;
+}

--- a/test/test_location-override.vhost.d/explicit-root-hash.nginx-proxy.test_42099b4af021e53fd8fd4e056c2568d7c2e3ffa8_location_override
+++ b/test/test_location-override.vhost.d/explicit-root-hash.nginx-proxy.test_42099b4af021e53fd8fd4e056c2568d7c2e3ffa8_location_override
@@ -1,0 +1,3 @@
+location / {
+    return 418;
+}

--- a/test/test_location-override.vhost.d/explicit-root-nohash.nginx-proxy.test_location_override
+++ b/test/test_location-override.vhost.d/explicit-root-nohash.nginx-proxy.test_location_override
@@ -1,0 +1,3 @@
+location / {
+    return 418;
+}

--- a/test/test_location-override.vhost.d/implicit-root-hash-and-nohash.nginx-proxy.test_42099b4af021e53fd8fd4e056c2568d7c2e3ffa8_location_override
+++ b/test/test_location-override.vhost.d/implicit-root-hash-and-nohash.nginx-proxy.test_42099b4af021e53fd8fd4e056c2568d7c2e3ffa8_location_override
@@ -1,0 +1,4 @@
+# This file should trump the file without the hash.
+location / {
+    return 418;
+}

--- a/test/test_location-override.vhost.d/implicit-root-hash-and-nohash.nginx-proxy.test_location_override
+++ b/test/test_location-override.vhost.d/implicit-root-hash-and-nohash.nginx-proxy.test_location_override
@@ -1,0 +1,4 @@
+# The file with the hash should trump this file.
+location / {
+    return 503;
+}

--- a/test/test_location-override.vhost.d/implicit-root-hash.nginx-proxy.test_42099b4af021e53fd8fd4e056c2568d7c2e3ffa8_location_override
+++ b/test/test_location-override.vhost.d/implicit-root-hash.nginx-proxy.test_42099b4af021e53fd8fd4e056c2568d7c2e3ffa8_location_override
@@ -1,0 +1,3 @@
+location / {
+    return 418;
+}

--- a/test/test_location-override.vhost.d/implicit-root-nohash.nginx-proxy.test_location_override
+++ b/test/test_location-override.vhost.d/implicit-root-nohash.nginx-proxy.test_location_override
@@ -1,0 +1,3 @@
+location / {
+    return 418;
+}

--- a/test/test_location-override.yml
+++ b/test/test_location-override.yml
@@ -1,0 +1,44 @@
+services:
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./test_location-override.vhost.d:/etc/nginx/vhost.d:ro
+
+  explicit-root:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: >-
+        explicit-root-nohash.nginx-proxy.test,
+        explicit-root-hash.nginx-proxy.test,
+        explicit-root-hash-and-nohash.nginx-proxy.test,
+        explicit-nonroot.nginx-proxy.test
+      VIRTUAL_PATH: /
+  explicit-foo:
+    image: web
+    expose:
+      - "82"
+    environment:
+      WEB_PORTS: "82"
+      VIRTUAL_HOST: >-
+        explicit-root-nohash.nginx-proxy.test,
+        explicit-root-hash.nginx-proxy.test,
+        explicit-root-hash-and-nohash.nginx-proxy.test,
+        explicit-nonroot.nginx-proxy.test
+      VIRTUAL_PATH: /foo/
+      VIRTUAL_DEST: /
+
+  # Same as explicit-root except VIRTUAL_PATH is left unset.
+  implicit-root:
+    image: web
+    expose:
+      - "83"
+    environment:
+      WEB_PORTS: "83"
+      VIRTUAL_HOST: >-
+        implicit-root-nohash.nginx-proxy.test,
+        implicit-root-hash.nginx-proxy.test,
+        implicit-root-hash-and-nohash.nginx-proxy.test,


### PR DESCRIPTION
Under the existing implementation, it would be impossible to change the actual behavior of the default location block, which attempts to proxy_pass onto the container.  This is probably acceptable for many use cases but not all.

This change adds some additional template logic that considers the existence of a `VIRTUAL_HOST_locations` (plural "locations" as opposed to the otherwise considered "location") configuration file.  When present, it will bypass generating any nginx `location` blocks and instead use those provided by the configuration file.  

This allows for some really advanced use cases with nginx's location filtering.  You can then forward the root location of a monitored domain onto a completely different container or even an entirely external host while still introducing logic that allows certain locations to forward to the container like normal.  

The README has been updated to reflect this. 

Fixes #1385
Fixes #1286 
Fixes #1086
Fixes #1003 
Fixes #567