### PR TITLE
Update README.md - sample yml needed expose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ services:
 
   whoami:
     image: jwilder/whoami
+    expose:
+      - "8000"
     environment:
       - VIRTUAL_HOST=whoami.local
 ```


### PR DESCRIPTION
Example docker-compose.yml does not work without defining an exposed port for whoami service.