### PR TITLE
Set proper X-Forwarded-Ssl for SSL-terminated setups

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -51,8 +51,8 @@ server_names_hash_bucket_size 128;
 ssl_dhparam /etc/nginx/dhparam/dhparam.pem;
 {{ end }}
 
-# Set appropriate X-Forwarded-Ssl header
-map $scheme $proxy_x_forwarded_ssl {
+# Set appropriate X-Forwarded-Ssl header based on $proxy_x_forwarded_proto
+map $proxy_x_forwarded_proto $proxy_x_forwarded_ssl {
   default off;
   https on;
 }


### PR DESCRIPTION
Hello! Thanks for awesome project!

I use nginx on same machine to terminate SSL and serve static files. So my nginx-proxy instances are http-only and use only docker network. That's why I got `X-Forwarded-Ssl` set always to "off" because it based on `$scheme`. In my PR I utilise `$proxy_x_forwarded_proto` mapping (which based on `X-Forwarded-Proto` header and falls back to `$scheme` if empty) to detect ssl connection.