### PR TITLE
Disable http/2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ You can activate the IPv6 support for the nginx-proxy container by passing the v
 
     $ docker run -d -p 80:80 -e ENABLE_IPV6=true -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
 
+### Disable HTTP/2
+
+You can disable support for HTTP/2 for the nginx-proxy container by passing the value `true` to the `NO_HTTP2` environment variable:
+    $ docker run -d -p 80:80 -e NO_HTTP2=true -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+
 ### Multiple Ports
 
 If your container exposes multiple ports, nginx-proxy will default to the service running on port 80.  If you need to specify a different port, you can set a VIRTUAL_PORT env var to select a different one.  If your container only exposes one port and it has a VIRTUAL_HOST env var set, that port will be selected.

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -99,11 +99,18 @@ server {
 	return 503;
 }
 
+{{ $no_http2 := eq (or ($.Env.NO_HTTP2) "" ) "true" }}
 {{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
+	{{ if $no_http2 }}
+	listen 443 ssl;
+	{{ else }}
 	listen 443 ssl http2;
-	{{ if $enable_ipv6 }}
+	{{ end }}
+	{{ if (and $enable_ipv6 $no_http2) }}
+	listen [::]:443 ssl;
+	{{ else if $enable_ipv6 }}
 	listen [::]:443 ssl http2;
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
@@ -204,10 +211,17 @@ server {
 
 server {
 	server_name {{ $host }};
+	{{ if $no_http2 }}
+	listen 443 ssl {{ $default_server }};
+	{{ else }}
 	listen 443 ssl http2 {{ $default_server }};
-	{{ if $enable_ipv6 }}
+	{{ end }}
+	{{ if (and $enable_ipv6 $no_http2) }}
+	listen [::]:443 ssl {{ $default_server }};
+	{{ else if $enable_ipv6 }}
 	listen [::]:443 ssl http2 {{ $default_server }};
 	{{ end }}
+
 	access_log /var/log/nginx/access.log vhost;
 
 	{{ if eq $network_tag "internal" }}
@@ -345,10 +359,17 @@ server {
 {{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
 	server_name {{ $host }};
+	{{ if $no_http2 }}
+	listen 443 ssl {{ $default_server }};
+	{{ else }}
 	listen 443 ssl http2 {{ $default_server }};
-	{{ if $enable_ipv6 }}
+	{{ end }}
+	{{ if (and $enable_ipv6 $no_http2) }}
+	listen [::]:443 ssl {{ $default_server }};
+	{{ else if $enable_ipv6 }}
 	listen [::]:443 ssl http2 {{ $default_server }};
 	{{ end }}
+
 	access_log /var/log/nginx/access.log vhost;
 	return 500;
 


### PR DESCRIPTION
# Changes proposed in this pull request

Allow users to disable support for HTTP/2 by introducing a `NO_HTTP2` environment variable for the nginx-proxy container.

This can be achieved by setting `NO_HTTP2: "true"` in the environment variables.

This is a proposed solution to #1055.

# Example

**Note:** the example only illustrates where the environment variable should be used.

```yml
version: '2'
services:
  nginx-proxy:
    image: jwilder/nginx-proxy
    container_name: nginx-proxy
    ports:
      - "80:80"
    volumes:
      - /var/run/docker.sock:/tmp/docker.sock:ro
    environment:
      - NO_HTTP2: "true"

  whoami:
    image: jwilder/whoami
    environment:
      - VIRTUAL_HOST=whoami.local
```