### PR TITLE
 Added ability to override proxy listening ports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ $ docker network connect my-other-network my-nginx-proxy
 
 In this example, the `my-nginx-proxy` container will be connected to `my-network` and `my-other-network` and will be able to proxy to other containers attached to those networks.
 
+### Listening Port
+
+If you want `nginx-proxy` to listen on a port different from the default port, use the environment variable `LISTEN_PORT`. E.g., to listen on port 8080, use `LISTEN_PORT=8080`. The default port is 80 for `HTTP` traffic.
+
+Likewise, you can set the default listen port for `HTTPS` traffic by setting `LISTEN_PORT_SSL`. E.g., `LISTEN_PORT_SSL=8443` would configure `nginx-proxy` to listen on port 8443 for `HTTPS` traffic. If you change the `HTTPS` port, the redirect for `HTTPS` traffic will also be configured to redirect to the custom port. The default port is 443 for `HTTPS` traffic.
+
 ### Internet vs. Local Network Access
 
 If you allow traffic from the public internet to access your `nginx-proxy` container, you may want to restrict some containers to the internal network only, so they cannot be accessed from the public internet.  On containers that should be restricted to the internal network, you should set the environment variable `NETWORK_ACCESS=internal`.  By default, the *internal* network is defined as `127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16`.  To change the list of networks considered internal, mount a file on the `nginx-proxy` at `/etc/nginx/network_internal.conf` with these contents, edited to suit your needs:

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -19,7 +19,7 @@
 			server 127.0.0.1 down;
 		{{ end }}
 	{{ end }}
-
+	
 {{ end }}
 
 # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
@@ -89,11 +89,13 @@ proxy_set_header Proxy "";
 {{ end }}
 
 {{ $enable_ipv6 := eq (or ($.Env.ENABLE_IPV6) "") "true" }}
+{{ $listen_port := coalesce $.Env.LISTEN_PORT "80" }}
+{{ $listen_port_ssl := coalesce $.Env.LISTEN_PORT_SSL "443" }}
 server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
-	listen 80;
+	listen {{ $listen_port }};
 	{{ if $enable_ipv6 }}
-	listen [::]:80;
+	listen [::]:{{ $listen_port }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 	return 503;
@@ -102,9 +104,9 @@ server {
 {{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
-	listen 443 ssl http2;
+	listen {{ $listen_port_ssl }} ssl http2;
 	{{ if $enable_ipv6 }}
-	listen [::]:443 ssl http2;
+	listen [::]:{{ $listen_port_ssl }} ssl http2;
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 	return 503;
@@ -193,20 +195,20 @@ upstream {{ $upstream_name }} {
 {{ if eq $https_method "redirect" }}
 server {
 	server_name {{ $host }};
-	listen 80 {{ $default_server }};
+	listen {{ $listen_port }} {{ $default_server }};
 	{{ if $enable_ipv6 }}
-	listen [::]:80 {{ $default_server }};
+	listen [::]:{{ $listen_port }} {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
-	return 301 https://$host$request_uri;
+	return 301 https://$host:{{ $listen_port_ssl -}}$request_uri;
 }
 {{ end }}
 
 server {
 	server_name {{ $host }};
-	listen 443 ssl http2 {{ $default_server }};
+	listen {{ $listen_port_ssl }} ssl http2 {{ $default_server }};
 	{{ if $enable_ipv6 }}
-	listen [::]:443 ssl http2 {{ $default_server }};
+	listen [::]:{{ $listen_port_ssl }} ssl http2 {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 
@@ -262,7 +264,7 @@ server {
 	ssl_trusted_certificate {{ printf "/etc/nginx/certs/%s.chain.pem" $cert }};
 	{{ end }}
 
-	{{ if (not (or (eq $https_method "noredirect") (eq $hsts "off"))) }}
+	{{ if (and (ne $https_method "noredirect") (ne $hsts "off")) }}
 	add_header Strict-Transport-Security "{{ trim $hsts }}" always;
 	{{ end }}
 
@@ -302,9 +304,9 @@ server {
 
 server {
 	server_name {{ $host }};
-	listen 80 {{ $default_server }};
+	listen {{ $listen_port }} {{ $default_server }};
 	{{ if $enable_ipv6 }}
-	listen [::]:80 {{ $default_server }};
+	listen [::]:{{ $listen_port }} {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 
@@ -345,9 +347,9 @@ server {
 {{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
 	server_name {{ $host }};
-	listen 443 ssl http2 {{ $default_server }};
+	listen {{ $listen_port_ssl }} ssl http2 {{ $default_server }};
 	{{ if $enable_ipv6 }}
-	listen [::]:443 ssl http2 {{ $default_server }};
+	listen [::]:{{ $listen_port_ssl }} ssl http2 {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 	return 500;

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -19,7 +19,7 @@
 			server 127.0.0.1 down;
 		{{ end }}
 	{{ end }}
-	
+
 {{ end }}
 
 # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
@@ -264,7 +264,7 @@ server {
 	ssl_trusted_certificate {{ printf "/etc/nginx/certs/%s.chain.pem" $cert }};
 	{{ end }}
 
-	{{ if (and (ne $https_method "noredirect") (ne $hsts "off")) }}
+	{{ if (not (or (eq $https_method "noredirect") (eq $hsts "off"))) }}
 	add_header Strict-Transport-Security "{{ trim $hsts }}" always;
 	{{ end }}
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -200,7 +200,7 @@ server {
 	listen [::]:{{ $listen_port }} {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
-	return 301 https://$host:{{ $listen_port_ssl -}}$request_uri;
+	return 301 https://$host{{ if not (eq $listen_port_ssl "443") }}:{{ $listen_port_ssl }}{{ end }}$request_uri;
 }
 {{ end }}
 

--- a/test/test_listen_port.py
+++ b/test/test_listen_port.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.mark.parametrize("subdomain", ["foo", "bar"])
+def test_web1_http_custom_port(docker_compose, nginxproxy, subdomain):
+    r = nginxproxy.get("http://%s.nginx-proxy.tld:8080/port" % subdomain, allow_redirects=False)
+    assert r.status_code == 200
+    assert "answer from port 81\n" in r.text

--- a/test/test_listen_port.yml
+++ b/test/test_listen_port.yml
@@ -1,0 +1,16 @@
+web1:
+  image: web
+  expose:
+    - "81"
+  environment:
+    WEB_PORTS: "81"
+    VIRTUAL_HOST: "*.nginx-proxy.tld"
+
+sut:
+  image: jwilder/nginx-proxy:test
+  volumes:
+    - /var/run/docker.sock:/tmp/docker.sock:ro
+    - ../lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro
+    - ./certs:/etc/nginx/certs:ro
+  environment:
+    LISTEN_PORT: 8080

--- a/test/test_listen_port.yml
+++ b/test/test_listen_port.yml
@@ -10,7 +10,6 @@ sut:
   image: jwilder/nginx-proxy:test
   volumes:
     - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ../lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro
-    - ./certs:/etc/nginx/certs:ro
+    - ./lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro
   environment:
     LISTEN_PORT: 8080

--- a/test/test_ssl/test_listen_port_ssl.py
+++ b/test/test_ssl/test_listen_port_ssl.py
@@ -1,0 +1,15 @@
+import pytest
+
+@pytest.mark.parametrize("subdomain", ["foo", "bar"])
+def test_web1_http_redirects_to_https(docker_compose, nginxproxy, subdomain):
+    r = nginxproxy.get("http://%s.nginx-proxy.tld:8080/" % subdomain, allow_redirects=False)
+    assert r.status_code == 301
+    assert "Location" in r.headers
+    assert "https://%s.nginx-proxy.tld:8443/" % subdomain == r.headers['Location']
+
+
+@pytest.mark.parametrize("subdomain", ["foo", "bar"])
+def test_web1_https_is_forwarded(docker_compose, nginxproxy, subdomain):
+    r = nginxproxy.get("https://%s.nginx-proxy.tld:8443/port" % subdomain, allow_redirects=False)
+    assert r.status_code == 200
+    assert "answer from port 81\n" in r.text

--- a/test/test_ssl/test_listen_port_ssl.yml
+++ b/test/test_ssl/test_listen_port_ssl.yml
@@ -1,0 +1,17 @@
+web1:
+  image: web
+  expose:
+    - "81"
+  environment:
+    WEB_PORTS: "81"
+    VIRTUAL_HOST: "*.nginx-proxy.tld"
+
+sut:
+  image: jwilder/nginx-proxy:test
+  volumes:
+    - /var/run/docker.sock:/tmp/docker.sock:ro
+    - ../lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro
+    - ./certs:/etc/nginx/certs:ro
+  environment:
+    LISTEN_PORT: 8080
+    LISTEN_PORT_SSL: 8443


### PR DESCRIPTION
With this change you can have nginx-proxy listen on a different port
from the default for HTTP and HTTPS. E.g., LISTEN_PORT=8080 sets the
HTTP port listen port to 8080 instead of 80. Likewise
LISTEN_PORT_SSL=8443 would use 8443 for HTTPS. This makes HTTP->HTTPS
redirection work properly when forwarding a port from a non-priviledged
VM (no ports < 1000) to nginx-proxy.

README.md is updated with the new variables available for config.

NOTE: To clarify, the entire reason for this feature is to allow proper automatic http->https redirection when nginx-proxy can't be bound to the standard 80 / 443 ports for http / https. Simply using docker port mapping (e.g., -p 8080:80 -p 8443:443) will properly map traffic onto the non-standard ports. But, the http->https redirection will use the standard ports. E.g., hitting http://someurl:8080 will end up redirecting to https://someurl with port redirection whereas it will hit https://someurl:8443 with this change (assuming you use 8080 and 8443).