### PR TITLE
alias host machine ip in /etc/hosts if not already present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update \
  && apt-get install -y -q --no-install-recommends \
     ca-certificates \
     wget \
+    iproute2 \
+    dnsutils \
  && apt-get clean \
  && rm -r /var/lib/apt/lists/*
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -4,6 +4,7 @@ LABEL maintainer="Jason Wilder mail@jasonwilder.com"
 # Install wget and install/updates certificates
 RUN apk add --no-cache --virtual .run-deps \
     ca-certificates bash wget openssl \
+    iproute2 bind-tools \
     && update-ca-certificates
 
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,4 +31,17 @@ if [ "$socketMissing" = 1 -a "$1" = forego -a "$2" = start -a "$3" = '-r' ]; the
 	exit 1
 fi
 
+# alias host machine IP if not already present
+DOCKER_HOST_IP=$(dig +short -4 host.docker.internal)
+if [[ -z $DOCKER_HOST_IP ]]; then
+  echo "host.docker.internal not resolved, attempting to identify docker host ip..."
+  DOCKER_HOST_IP=`/sbin/ip route|awk '/default/ { print $3 }'`
+  echo "found host.docker.internal at $DOCKER_HOST_IP, adding to /etc/hosts..."
+  echo "$DOCKER_HOST_IP	host.docker.internal" >> /etc/hosts
+  echo "$DOCKER_HOST_IP	docker.for.mac.localhost" >> /etc/hosts
+  echo "$DOCKER_HOST_IP	docker.for.win.localhost" >> /etc/hosts
+else
+  echo "host.docker.internal resolved to $DOCKER_HOST_IP, not modifying /etc/hosts"
+fi
+
 exec "$@"


### PR DESCRIPTION
Docker on Mac and Windows inserts an alias for `host.docker.internal` (introduced in 18.03) as well as the alternative `docker.for.mac.localhost` and `docker.for.win.localhost` (deprecated but still often used) - it points at the IP address of the host machine running the container. This allows the nginx proxy to direct requests at the host via one of those aliases (canonically `host.docker.internal`). However, Docker on Linux does not yet support this alias.

This PR adds a bit of logic to the `docker-entrypoint.sh` script which will create this alias if not already present. It is likely (but not guaranteed) that Docker on Linux might eventually support `host.docker.internal` natively, but until then, this allows the proxy to make use of the aliases.

### docker for mac
![image](https://user-images.githubusercontent.com/22151295/55636879-bf360480-57bb-11e9-9a80-4d9fc234b4a3.png)

![image](https://user-images.githubusercontent.com/22151295/55638592-784a0e00-57bf-11e9-880e-3211c3ebeb9c.png)

### docker on linux
![image](https://user-images.githubusercontent.com/22151295/55637048-1b992400-57bc-11e9-84df-1943efb0feee.png)

![image](https://user-images.githubusercontent.com/22151295/55638637-94e64600-57bf-11e9-8f45-416bbaa834f6.png)

### test-debian

<details>
<summary>113 passed, 4 skipped, 4 xfailed, 8 xpassed in 248.45 seconds</summary>

```bash
===================================================== test session starts ======================================================
platform linux2 -- Python 2.7.16, pytest-3.0.5, py-1.8.0, pluggy-0.4.0 -- /usr/local/bin/python
rootdir: /Users/raph/src/nginx-proxy/test, inifile: pytest.ini
collected 129 items

test_DOCKER_HOST_unix_socket.py::test_unknown_virtual_host PASSED
test_DOCKER_HOST_unix_socket.py::test_forwards_to_web1 PASSED
test_DOCKER_HOST_unix_socket.py::test_forwards_to_web2 PASSED
test_composev2.py::test_unknown_virtual_host PASSED
test_composev2.py::test_forwards_to_whoami PASSED
test_default-host.py::test_fallback_on_default PASSED
test_events.py::test_nginx_proxy_behavior_when_alone PASSED
test_events.py::test_new_container_is_detected PASSED
test_ipv6.py::test_unknown_virtual_host_ipv4 PASSED
test_ipv6.py::test_forwards_to_web1_ipv4 PASSED
test_ipv6.py::test_forwards_to_web2_ipv4 PASSED
test_ipv6.py::test_unknown_virtual_host_ipv6 SKIPPED
test_ipv6.py::test_forwards_to_web1_ipv6 SKIPPED
test_ipv6.py::test_forwards_to_web2_ipv6 SKIPPED
test_multiple-hosts.py::test_unknown_virtual_host_is_503 PASSED
test_multiple-hosts.py::test_webA_is_forwarded PASSED
test_multiple-hosts.py::test_webB_is_forwarded PASSED
test_multiple-networks.py::test_unknown_virtual_host PASSED
test_multiple-networks.py::test_forwards_to_web1 PASSED
test_multiple-networks.py::test_forwards_to_web2 PASSED
test_nominal.py::test_unknown_virtual_host PASSED
test_nominal.py::test_forwards_to_web1 PASSED
test_nominal.py::test_forwards_to_web2 PASSED
test_nominal.py::test_ipv6_is_disabled_by_default SKIPPED
test_wildcard_host.py::test_wildcard_prefix[f00.nginx-proxy.test-81] PASSED
test_wildcard_host.py::test_wildcard_prefix[bar.nginx-proxy.test-81] PASSED
test_wildcard_host.py::test_wildcard_prefix[test.nginx-proxy.f00-82] PASSED
test_wildcard_host.py::test_wildcard_prefix[test.nginx-proxy.bar-82] PASSED
test_wildcard_host.py::test_wildcard_prefix[web3.123.nginx-proxy.regexp-83] PASSED
test_wildcard_host.py::test_wildcard_prefix[web3.ABC.nginx-proxy.regexp-83] PASSED
test_wildcard_host.py::test_wildcard_prefix[web3.123.ABC.nginx-proxy.regexp-83] PASSED
test_wildcard_host.py::test_wildcard_prefix[web3.123-ABC.nginx-proxy.regexp-83] PASSED
test_wildcard_host.py::test_wildcard_prefix[web3.whatever.nginx-proxy.regexp-to-infinity-and-beyond-83] PASSED
test_wildcard_host.py::test_wildcard_prefix[web4.123.nginx-proxy.regexp-84] PASSED
test_wildcard_host.py::test_wildcard_prefix[web4.ABC.nginx-proxy.regexp-84] PASSED
test_wildcard_host.py::test_wildcard_prefix[web4.123.ABC.nginx-proxy.regexp-84] PASSED
test_wildcard_host.py::test_wildcard_prefix[web4.123-ABC.nginx-proxy.regexp-84] PASSED
test_wildcard_host.py::test_wildcard_prefix[web4.whatever.nginx-proxy.regexp-84] PASSED
test_wildcard_host.py::test_non_matching_host_is_503[unexpected.nginx-proxy.tld] PASSED
test_wildcard_host.py::test_non_matching_host_is_503[web4.whatever.nginx-proxy.regexp-to-infinity-and-beyond] PASSED
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_unknown_virtual_host_is_503 XPASS
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_http_web_is_301 XPASS
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_https_web_is_200 XPASS
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_delete_cert_and_restart_reverseproxy xfail
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_unknown_virtual_host_is_still_503 xfail
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_http_web_is_now_200 xfail
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_https_web_is_now_broken_since_there_is_no_cert xfail
stress_tests/test_unreachable_network/test_unreachable_net.py::test_default_nginx_welcome_page_should_not_be_served XPASS
stress_tests/test_unreachable_network/test_unreachable_net.py::test_unknown_virtual_host_is_503 XPASS
stress_tests/test_unreachable_network/test_unreachable_net.py::test_http_web_a_is_forwarded XPASS
stress_tests/test_unreachable_network/test_unreachable_net.py::test_http_web_b_gets_an_error XPASS
stress_tests/test_unreachable_network/test_unreachable_net.py::test_reverseproxy_survive_restart XPASS
test_custom/test_defaults-location.py::test_custom_default_conf_does_not_apply_to_unknown_vhost PASSED
test_custom/test_defaults-location.py::test_custom_default_conf_applies_to_web1 PASSED
test_custom/test_defaults-location.py::test_custom_default_conf_applies_to_web2 PASSED
test_custom/test_defaults-location.py::test_custom_default_conf_is_overriden_for_web3 PASSED
test_custom/test_defaults.py::test_custom_conf_does_not_apply_to_unknown_vhost PASSED
test_custom/test_defaults.py::test_custom_conf_applies_to_web1 PASSED
test_custom/test_defaults.py::test_custom_conf_applies_to_web2 PASSED
test_custom/test_location-per-vhost.py::test_custom_conf_does_not_apply_to_unknown_vhost PASSED
test_custom/test_location-per-vhost.py::test_custom_conf_applies_to_web1 PASSED
test_custom/test_location-per-vhost.py::test_custom_conf_does_not_apply_to_web2 PASSED
test_custom/test_location-per-vhost.py::test_custom_block_is_present_in_nginx_generated_conf PASSED
test_custom/test_per-vhost.py::test_custom_conf_does_not_apply_to_unknown_vhost PASSED
test_custom/test_per-vhost.py::test_custom_conf_applies_to_web1 PASSED
test_custom/test_per-vhost.py::test_custom_conf_does_not_apply_to_web2 PASSED
test_custom/test_proxy-wide.py::test_custom_conf_does_not_apply_to_unknown_vhost PASSED
test_custom/test_proxy-wide.py::test_custom_conf_applies_to_web1 PASSED
test_custom/test_proxy-wide.py::test_custom_conf_applies_to_web2 PASSED
test_dockergen/test_dockergen_v2.py::test_unknown_virtual_host_is_503 PASSED
test_dockergen/test_dockergen_v2.py::test_forwards_to_whoami PASSED
test_dockergen/test_dockergen_v3.py::test_unknown_virtual_host_is_503 PASSED
test_dockergen/test_dockergen_v3.py::test_forwards_to_whoami PASSED
test_headers/test_http.py::test_arbitrary_headers_are_passed_on PASSED
test_headers/test_http.py::test_X_Forwarded_For_is_generated PASSED
test_headers/test_http.py::test_X_Forwarded_For_is_passed_on PASSED
test_headers/test_http.py::test_X_Forwarded_Proto_is_generated PASSED
test_headers/test_http.py::test_X_Forwarded_Proto_is_passed_on PASSED
test_headers/test_http.py::test_X_Forwarded_Port_is_generated PASSED
test_headers/test_http.py::test_X_Forwarded_Port_is_passed_on PASSED
test_headers/test_http.py::test_X_Forwarded_Ssl_is_generated PASSED
test_headers/test_http.py::test_X_Forwarded_Ssl_is_overwritten PASSED
test_headers/test_http.py::test_X_Real_IP_is_generated PASSED
test_headers/test_http.py::test_Host_is_passed_on PASSED
test_headers/test_http.py::test_httpoxy_safe PASSED
test_headers/test_https.py::test_arbitrary_headers_are_passed_on PASSED
test_headers/test_https.py::test_X_Forwarded_For_is_generated PASSED
test_headers/test_https.py::test_X_Forwarded_For_is_passed_on PASSED
test_headers/test_https.py::test_X_Forwarded_Proto_is_generated PASSED
test_headers/test_https.py::test_X_Forwarded_Proto_is_passed_on PASSED
test_headers/test_https.py::test_X_Forwarded_Port_is_generated PASSED
test_headers/test_https.py::test_X_Forwarded_Port_is_passed_on PASSED
test_headers/test_https.py::test_X_Forwarded_Ssl_is_generated PASSED
test_headers/test_https.py::test_X_Forwarded_Ssl_is_overwritten PASSED
test_headers/test_https.py::test_X_Real_IP_is_generated PASSED
test_headers/test_https.py::test_Host_is_passed_on PASSED
test_headers/test_https.py::test_httpoxy_safe PASSED
test_multiple-ports/test_VIRTUAL_PORT.py::test_answer_is_served_from_chosen_port PASSED
test_multiple-ports/test_default-80.py::test_answer_is_served_from_port_80_by_default PASSED
test_multiple-ports/test_single-port-not-80.py::test_answer_is_served_from_exposed_port_even_if_not_80 PASSED
test_ssl/test_dhparam.py::test_dhparam_is_not_generated_if_present PASSED
test_ssl/test_dhparam.py::test_web5_https_works PASSED
test_ssl/test_dhparam.py::test_web5_dhparam_is_used PASSED
test_ssl/test_dhparam_generation.py::test_dhparam_is_generated_if_missing PASSED
test_ssl/test_hsts.py::test_web1_HSTS_default PASSED
test_ssl/test_hsts.py::test_web1_HSTS_error PASSED
test_ssl/test_hsts.py::test_web2_HSTS_off PASSED
test_ssl/test_hsts.py::test_web3_HSTS_custom PASSED
test_ssl/test_hsts.py::test_web4_HSTS_off_noredirect PASSED
test_ssl/test_nohttp.py::test_web2_http_is_not_forwarded PASSED
test_ssl/test_nohttp.py::test_web2_https_is_forwarded PASSED
test_ssl/test_nohttp.py::test_web2_HSTS_policy_is_active PASSED
test_ssl/test_nohttps.py::test_http_is_forwarded PASSED
test_ssl/test_nohttps.py::test_https_is_disabled PASSED
test_ssl/test_noredirect.py::test_web3_http_is_forwarded PASSED
test_ssl/test_noredirect.py::test_web3_https_is_forwarded PASSED
test_ssl/test_noredirect.py::test_web2_HSTS_policy_is_inactive PASSED
test_ssl/test_wildcard.py::test_web1_http_redirects_to_https[foo] PASSED
test_ssl/test_wildcard.py::test_web1_http_redirects_to_https[bar] PASSED
test_ssl/test_wildcard.py::test_web1_https_is_forwarded[foo] PASSED
test_ssl/test_wildcard.py::test_web1_https_is_forwarded[bar] PASSED
test_ssl/test_wildcard.py::test_web1_HSTS_policy_is_active[foo] PASSED
test_ssl/test_wildcard.py::test_web1_HSTS_policy_is_active[bar] PASSED
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_http_redirects_to_https[1-True] PASSED
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_http_redirects_to_https[2-True] PASSED
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_http_redirects_to_https[3-False] PASSED
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_https_get_served[1] PASSED
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_https_get_served[2] PASSED
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_web3_https_is_500_and_SSL_validation_fails PASSED
=================================================== short test summary info ====================================================
SKIP [4] /Users/raph/src/nginx-proxy/test/conftest.py:133: This system does not support IPv6
================================ 113 passed, 4 skipped, 4 xfailed, 8 xpassed in 248.45 seconds =================================
```

</details>

### test-alpine

<details>
<summary>113 passed, 4 skipped, 4 xfailed, 8 xpassed in 236.18 seconds</summary>

```bash
===================================================== test session starts ======================================================
platform linux2 -- Python 2.7.16, pytest-3.0.5, py-1.8.0, pluggy-0.4.0 -- /usr/local/bin/python
rootdir: /Users/raph/src/nginx-proxy/test, inifile: pytest.ini
collected 129 items

test_DOCKER_HOST_unix_socket.py::test_unknown_virtual_host PASSED
test_DOCKER_HOST_unix_socket.py::test_forwards_to_web1 PASSED
test_DOCKER_HOST_unix_socket.py::test_forwards_to_web2 PASSED
test_composev2.py::test_unknown_virtual_host PASSED
test_composev2.py::test_forwards_to_whoami PASSED
test_default-host.py::test_fallback_on_default PASSED
test_events.py::test_nginx_proxy_behavior_when_alone PASSED
test_events.py::test_new_container_is_detected PASSED
test_ipv6.py::test_unknown_virtual_host_ipv4 PASSED
test_ipv6.py::test_forwards_to_web1_ipv4 PASSED
test_ipv6.py::test_forwards_to_web2_ipv4 PASSED
test_ipv6.py::test_unknown_virtual_host_ipv6 SKIPPED
test_ipv6.py::test_forwards_to_web1_ipv6 SKIPPED
test_ipv6.py::test_forwards_to_web2_ipv6 SKIPPED
test_multiple-hosts.py::test_unknown_virtual_host_is_503 PASSED
test_multiple-hosts.py::test_webA_is_forwarded PASSED
test_multiple-hosts.py::test_webB_is_forwarded PASSED
test_multiple-networks.py::test_unknown_virtual_host PASSED
test_multiple-networks.py::test_forwards_to_web1 PASSED
test_multiple-networks.py::test_forwards_to_web2 PASSED
test_nominal.py::test_unknown_virtual_host PASSED
test_nominal.py::test_forwards_to_web1 PASSED
test_nominal.py::test_forwards_to_web2 PASSED
test_nominal.py::test_ipv6_is_disabled_by_default SKIPPED
test_wildcard_host.py::test_wildcard_prefix[f00.nginx-proxy.test-81] PASSED
test_wildcard_host.py::test_wildcard_prefix[bar.nginx-proxy.test-81] PASSED
test_wildcard_host.py::test_wildcard_prefix[test.nginx-proxy.f00-82] PASSED
test_wildcard_host.py::test_wildcard_prefix[test.nginx-proxy.bar-82] PASSED
test_wildcard_host.py::test_wildcard_prefix[web3.123.nginx-proxy.regexp-83] PASSED
test_wildcard_host.py::test_wildcard_prefix[web3.ABC.nginx-proxy.regexp-83] PASSED
test_wildcard_host.py::test_wildcard_prefix[web3.123.ABC.nginx-proxy.regexp-83] PASSED
test_wildcard_host.py::test_wildcard_prefix[web3.123-ABC.nginx-proxy.regexp-83] PASSED
test_wildcard_host.py::test_wildcard_prefix[web3.whatever.nginx-proxy.regexp-to-infinity-and-beyond-83] PASSED
test_wildcard_host.py::test_wildcard_prefix[web4.123.nginx-proxy.regexp-84] PASSED
test_wildcard_host.py::test_wildcard_prefix[web4.ABC.nginx-proxy.regexp-84] PASSED
test_wildcard_host.py::test_wildcard_prefix[web4.123.ABC.nginx-proxy.regexp-84] PASSED
test_wildcard_host.py::test_wildcard_prefix[web4.123-ABC.nginx-proxy.regexp-84] PASSED
test_wildcard_host.py::test_wildcard_prefix[web4.whatever.nginx-proxy.regexp-84] PASSED
test_wildcard_host.py::test_non_matching_host_is_503[unexpected.nginx-proxy.tld] PASSED
test_wildcard_host.py::test_non_matching_host_is_503[web4.whatever.nginx-proxy.regexp-to-infinity-and-beyond] PASSED
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_unknown_virtual_host_is_503 XPASS
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_http_web_is_301 XPASS
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_https_web_is_200 XPASS
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_delete_cert_and_restart_reverseproxy xfail
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_unknown_virtual_host_is_still_503 xfail
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_http_web_is_now_200 xfail
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_https_web_is_now_broken_since_there_is_no_cert xfail
stress_tests/test_unreachable_network/test_unreachable_net.py::test_default_nginx_welcome_page_should_not_be_served XPASS
stress_tests/test_unreachable_network/test_unreachable_net.py::test_unknown_virtual_host_is_503 XPASS
stress_tests/test_unreachable_network/test_unreachable_net.py::test_http_web_a_is_forwarded XPASS
stress_tests/test_unreachable_network/test_unreachable_net.py::test_http_web_b_gets_an_error XPASS
stress_tests/test_unreachable_network/test_unreachable_net.py::test_reverseproxy_survive_restart XPASS
test_custom/test_defaults-location.py::test_custom_default_conf_does_not_apply_to_unknown_vhost PASSED
test_custom/test_defaults-location.py::test_custom_default_conf_applies_to_web1 PASSED
test_custom/test_defaults-location.py::test_custom_default_conf_applies_to_web2 PASSED
test_custom/test_defaults-location.py::test_custom_default_conf_is_overriden_for_web3 PASSED
test_custom/test_defaults.py::test_custom_conf_does_not_apply_to_unknown_vhost PASSED
test_custom/test_defaults.py::test_custom_conf_applies_to_web1 PASSED
test_custom/test_defaults.py::test_custom_conf_applies_to_web2 PASSED
test_custom/test_location-per-vhost.py::test_custom_conf_does_not_apply_to_unknown_vhost PASSED
test_custom/test_location-per-vhost.py::test_custom_conf_applies_to_web1 PASSED
test_custom/test_location-per-vhost.py::test_custom_conf_does_not_apply_to_web2 PASSED
test_custom/test_location-per-vhost.py::test_custom_block_is_present_in_nginx_generated_conf PASSED
test_custom/test_per-vhost.py::test_custom_conf_does_not_apply_to_unknown_vhost PASSED
test_custom/test_per-vhost.py::test_custom_conf_applies_to_web1 PASSED
test_custom/test_per-vhost.py::test_custom_conf_does_not_apply_to_web2 PASSED
test_custom/test_proxy-wide.py::test_custom_conf_does_not_apply_to_unknown_vhost PASSED
test_custom/test_proxy-wide.py::test_custom_conf_applies_to_web1 PASSED
test_custom/test_proxy-wide.py::test_custom_conf_applies_to_web2 PASSED
test_dockergen/test_dockergen_v2.py::test_unknown_virtual_host_is_503 PASSED
test_dockergen/test_dockergen_v2.py::test_forwards_to_whoami PASSED
test_dockergen/test_dockergen_v3.py::test_unknown_virtual_host_is_503 PASSED
test_dockergen/test_dockergen_v3.py::test_forwards_to_whoami PASSED
test_headers/test_http.py::test_arbitrary_headers_are_passed_on PASSED
test_headers/test_http.py::test_X_Forwarded_For_is_generated PASSED
test_headers/test_http.py::test_X_Forwarded_For_is_passed_on PASSED
test_headers/test_http.py::test_X_Forwarded_Proto_is_generated PASSED
test_headers/test_http.py::test_X_Forwarded_Proto_is_passed_on PASSED
test_headers/test_http.py::test_X_Forwarded_Port_is_generated PASSED
test_headers/test_http.py::test_X_Forwarded_Port_is_passed_on PASSED
test_headers/test_http.py::test_X_Forwarded_Ssl_is_generated PASSED
test_headers/test_http.py::test_X_Forwarded_Ssl_is_overwritten PASSED
test_headers/test_http.py::test_X_Real_IP_is_generated PASSED
test_headers/test_http.py::test_Host_is_passed_on PASSED
test_headers/test_http.py::test_httpoxy_safe PASSED
test_headers/test_https.py::test_arbitrary_headers_are_passed_on PASSED
test_headers/test_https.py::test_X_Forwarded_For_is_generated PASSED
test_headers/test_https.py::test_X_Forwarded_For_is_passed_on PASSED
test_headers/test_https.py::test_X_Forwarded_Proto_is_generated PASSED
test_headers/test_https.py::test_X_Forwarded_Proto_is_passed_on PASSED
test_headers/test_https.py::test_X_Forwarded_Port_is_generated PASSED
test_headers/test_https.py::test_X_Forwarded_Port_is_passed_on PASSED
test_headers/test_https.py::test_X_Forwarded_Ssl_is_generated PASSED
test_headers/test_https.py::test_X_Forwarded_Ssl_is_overwritten PASSED
test_headers/test_https.py::test_X_Real_IP_is_generated PASSED
test_headers/test_https.py::test_Host_is_passed_on PASSED
test_headers/test_https.py::test_httpoxy_safe PASSED
test_multiple-ports/test_VIRTUAL_PORT.py::test_answer_is_served_from_chosen_port PASSED
test_multiple-ports/test_default-80.py::test_answer_is_served_from_port_80_by_default PASSED
test_multiple-ports/test_single-port-not-80.py::test_answer_is_served_from_exposed_port_even_if_not_80 PASSED
test_ssl/test_dhparam.py::test_dhparam_is_not_generated_if_present PASSED
test_ssl/test_dhparam.py::test_web5_https_works PASSED
test_ssl/test_dhparam.py::test_web5_dhparam_is_used PASSED
test_ssl/test_dhparam_generation.py::test_dhparam_is_generated_if_missing PASSED
test_ssl/test_hsts.py::test_web1_HSTS_default PASSED
test_ssl/test_hsts.py::test_web1_HSTS_error PASSED
test_ssl/test_hsts.py::test_web2_HSTS_off PASSED
test_ssl/test_hsts.py::test_web3_HSTS_custom PASSED
test_ssl/test_hsts.py::test_web4_HSTS_off_noredirect PASSED
test_ssl/test_nohttp.py::test_web2_http_is_not_forwarded PASSED
test_ssl/test_nohttp.py::test_web2_https_is_forwarded PASSED
test_ssl/test_nohttp.py::test_web2_HSTS_policy_is_active PASSED
test_ssl/test_nohttps.py::test_http_is_forwarded PASSED
test_ssl/test_nohttps.py::test_https_is_disabled PASSED
test_ssl/test_noredirect.py::test_web3_http_is_forwarded PASSED
test_ssl/test_noredirect.py::test_web3_https_is_forwarded PASSED
test_ssl/test_noredirect.py::test_web2_HSTS_policy_is_inactive PASSED
test_ssl/test_wildcard.py::test_web1_http_redirects_to_https[foo] PASSED
test_ssl/test_wildcard.py::test_web1_http_redirects_to_https[bar] PASSED
test_ssl/test_wildcard.py::test_web1_https_is_forwarded[foo] PASSED
test_ssl/test_wildcard.py::test_web1_https_is_forwarded[bar] PASSED
test_ssl/test_wildcard.py::test_web1_HSTS_policy_is_active[foo] PASSED
test_ssl/test_wildcard.py::test_web1_HSTS_policy_is_active[bar] PASSED
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_http_redirects_to_https[1-True] PASSED
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_http_redirects_to_https[2-True] PASSED
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_http_redirects_to_https[3-False] PASSED
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_https_get_served[1] PASSED
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_https_get_served[2] PASSED
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_web3_https_is_500_and_SSL_validation_fails PASSED
=================================================== short test summary info ====================================================
SKIP [4] /Users/raph/src/nginx-proxy/test/conftest.py:133: This system does not support IPv6

================================ 113 passed, 4 skipped, 4 xfailed, 8 xpassed in 236.18 seconds =================================
```

</details>