### PR TITLE
* Initial ARM support.

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,0 +1,38 @@
+FROM nginx:mainline-alpine
+LABEL authors="Ludovic Roguet <code@fourteenislands.io>"
+LABEL maintainer="Leonardo Amaral <docker@leonardoamaral.com.br>"
+
+# Install wget and install/updates certificates
+RUN apk add --no-cache --virtual .run-deps \
+    ca-certificates bash wget openssl \
+    && update-ca-certificates
+
+# Configure Nginx and apply fix for very long server names
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
+ && sed -i 's/worker_processes 1/worker_processes auto/' /etc/nginx/nginx.conf
+
+# Install Forego
+RUN wget https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-arm.tgz \
+ && tar -C /usr/local/bin -xvzf forego-stable-linux-arm.tgz \
+ && chmod a+x /usr/local/bin/forego \
+ && rm /forego-stable-linux-arm.tgz
+
+ENV DOCKER_GEN_VERSION 0.7.4
+
+# Install docker-gen
+
+RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-armhf-$DOCKER_GEN_VERSION.tar.gz \
+ && tar -C /usr/local/bin -xvzf docker-gen-linux-armhf-$DOCKER_GEN_VERSION.tar.gz \
+ && rm /docker-gen-linux-armhf-$DOCKER_GEN_VERSION.tar.gz
+
+COPY network_internal.conf /etc/nginx/
+
+COPY . /app/
+WORKDIR /app/
+
+ENV DOCKER_HOST unix:///tmp/docker.sock
+
+VOLUME ["/etc/nginx/certs", "/etc/nginx/dhparam"]
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["forego", "start", "-r"]


### PR DESCRIPTION
Hello @jwilder 

I made a image based on https://github.com/lroguet/rpi-nginx-proxy and when upgrading everything (Result in https://github.com/leleobhz/rpi-nginx-proxy) I noticed I may sync the arm versions of everything to you repo. 

I've tested it sucessully in a RPI 1 - and I've not created a aarch64 image yet (But I think its possible to do binary builds if https://github.com/jwilder/docker-gen/releases provides aarch64 binaries, since https://dl.equinox.io/ddollar/forego/stable does have arm64 stable images).

If you provide binaries or a way to compile docker-gen, I can create the aarch64 in another pull request :)

Also, did not changed anything in README.md since I think first the image need to be ok and published to Docker hub before write a third option.

Also I think its possible to use Debian image too. If you want, I can build it too.