### PR TITLE
Change dhparam positional args to be inherited vars, standardize naming

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # Warn if the DOCKER_HOST socket does not exist
 if [[ $DOCKER_HOST = unix://* ]]; then
 	socket_file=${DOCKER_HOST#unix://}
-	if ! [ -S $socket_file ]; then
+	if ! [ -S "$socket_file" ]; then
 		cat >&2 <<-EOT
 			ERROR: you need to share your Docker host socket with a volume at $socket_file
 			Typically you should run your nginxproxy/nginx-proxy with: \`-v /var/run/docker.sock:$socket_file:ro\`
@@ -18,14 +18,14 @@ fi
 /app/generate-dhparam.sh
 
 # Compute the DNS resolvers for use in the templates - if the IP contains ":", it's IPv6 and must be enclosed in []
-export RESOLVERS=$(awk '$1 == "nameserver" {print ($2 ~ ":")? "["$2"]": $2}' ORS=' ' /etc/resolv.conf | sed 's/ *$//g')
-if [ "x$RESOLVERS" = "x" ]; then
+RESOLVERS=$(awk '$1 == "nameserver" {print ($2 ~ ":")? "["$2"]": $2}' ORS=' ' /etc/resolv.conf | sed 's/ *$//g'); export RESOLVERS
+if [ "$RESOLVERS" = "" ]; then
     echo "Warning: unable to determine DNS resolvers for nginx" >&2
     unset RESOLVERS
 fi
 
 # If the user has run the default command and the socket doesn't exist, fail
-if [ "$socketMissing" = 1 -a "$1" = forego -a "$2" = start -a "$3" = '-r' ]; then
+if [ "$socketMissing" = 1 ] && [ "$1" = forego ] && [ "$2" = start ] && [ "$3" = '-r' ]; then
 	exit 1
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,9 +15,7 @@ if [[ $DOCKER_HOST = unix://* ]]; then
 fi
 
 # Generate dhparam file if required
-# Note: if $DHPARAM_BITS is not defined, generate-dhparam.sh will use 4096 as a default
-# Note2: if $DHPARAM_GENERATION is set to false in environment variable, dh param generator will skip completely
-/app/generate-dhparam.sh $DHPARAM_BITS $DHPARAM_GENERATION
+/app/generate-dhparam.sh
 
 # Compute the DNS resolvers for use in the templates - if the IP contains ":", it's IPv6 and must be enclosed in []
 export RESOLVERS=$(awk '$1 == "nameserver" {print ($2 ~ ":")? "["$2"]": $2}' ORS=' ' /etc/resolv.conf | sed 's/ *$//g')

--- a/generate-dhparam.sh
+++ b/generate-dhparam.sh
@@ -15,7 +15,7 @@ GEN_LOCKFILE="/tmp/dhparam_generating.lock"
 PREGEN_HASH=$(md5sum $PREGEN_DHPARAM_FILE | cut -d" " -f1)
 if [[ -f $DHPARAM_FILE ]]; then
     CURRENT_HASH=$(md5sum $DHPARAM_FILE | cut -d" " -f1)
-    if [[ $PREGEN_HASH != $CURRENT_HASH ]]; then
+    if [[ $PREGEN_HASH != "$CURRENT_HASH" ]]; then
         # There is already a dhparam, and it's not the default
         echo "Custom dhparam.pem file found, generation skipped"
         exit 0
@@ -44,10 +44,10 @@ touch $GEN_LOCKFILE
 # Generate a new dhparam in the background in a low priority and reload nginx when finished (grep removes the progress indicator).
 (
     (
-        nice -n +5 openssl dhparam -dsaparam -out $DHPARAM_FILE.tmp $DHPARAM_BITS 2>&1 \
+        nice -n +5 openssl dhparam -dsaparam -out $DHPARAM_FILE.tmp "$DHPARAM_BITS" 2>&1 \
         && mv $DHPARAM_FILE.tmp $DHPARAM_FILE \
         && echo "dhparam generation complete, reloading nginx" \
         && nginx -s reload
     ) | grep -vE '^[\.+]+'
     rm $GEN_LOCKFILE
-) &disown
+) & disown

--- a/generate-dhparam.sh
+++ b/generate-dhparam.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -e
 
-# The first argument is the bit depth of the dhparam, or 4096 if unspecified
-DHPARAM_BITS=${1:-4096}
-GENERATE_DHPARAM=${2:-true}
+# DHPARAM_BITS is the bit depth of the dhparam, or 4096 if unspecified
+DHPARAM_BITS=${DHPARAM_BITS:-4096}
+# DHPARAM_GENERATION=false skips dhparam generation
+DHPARAM_GENERATION=${DHPARAM_GENERATION:-true}
 
 # If a dhparam file is not available, use the pre-generated one and generate a new one in the background.
 # Note that /etc/nginx/dhparam is a volume, so this dhparam will persist restarts.
@@ -26,7 +27,7 @@ if [[ -f $DHPARAM_FILE ]]; then
     fi
 fi
 
-if [[ $GENERATE_DHPARAM =~ ^[Ff][Aa][Ll][Ss][Ee]$ ]]; then
+if [[ $DHPARAM_GENERATION =~ ^[Ff][Aa][Ll][Ss][Ee]$ ]]; then
     echo "Skipping Diffie-Hellman parameters generation and Ignoring pre-generated dhparam.pem"
     exit 0
 fi


### PR DESCRIPTION
PR #913 added `DHPARAM_GENERATION` as a positional argument to generate-dhparam.sh. However, since it was the second positional argument,`DHPARAM_BITS` would also have to be defined or `DHPARAM_GENERATION` would be read into `DHPARAM_BITS`. This changes the arguments to be inherited variables which do not depend on order, just declaration.

Also change instances of `GENERATE_DHPARAM` to `DHPARAM_GENERATION` since it's unnecessary to have another variable. I think `GENERATE_DHPARAM` is actually a better name (verb vs. noun), but `DHPARAM_GENERATION` is already defined and may break someone if changed.

Addresses https://github.com/jwilder/nginx-proxy/pull/913#issuecomment-476014691

----

### Behavior before:
```
$ docker run -it --rm -e "DHPARAM_GENERATION=false" testing /bin/bash
WARNING: /etc/nginx/dhparam/dhparam.pem was not found. A pre-generated dhparam.pem will be used for now while a new one
is being generated in the background.  Once the new dhparam.pem is in place, nginx will be reloaded.
dhparam: Can't parse "false" as a number
```
### Behavior after:
```
$ docker run --rm -e "DHPARAM_GENERATION=false" testing /bin/bash
Skipping Diffie-Hellman parameters generation and Ignoring pre-generated dhparam.pem
```