### PR TITLE
Stop marking 127.0.0.1 as upstream and as down

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -15,8 +15,6 @@
 		# {{ .Container.Name }}
 		{{ if .Network.IP }}
 			server {{ .Network.IP }} down;
-		{{ else }}
-			server 127.0.0.1 down;
 		{{ end }}
 	{{ end }}
 
@@ -142,9 +140,6 @@ upstream {{ $upstream_name }} {
 					{{ $address := where $container.Addresses "Port" $port | first }}
 					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 				{{ end }}
-			{{ else }}
-				# Cannot connect to network of this container
-				server 127.0.0.1 down;
 			{{ end }}
 		{{ end }}
 	{{ end }}


### PR DESCRIPTION
This patch fixes a critical condition in which the whole LB is down.        
    
    [emerg] 28#28: invalid number of arguments in "upstream" directive        
    
And:        
    
    Generated '/etc/nginx/conf.d/default.conf' from 12 containers        
    Running 'nginx -s reload'        
    Error running notify command: nginx -s reload, exit status 1        
    Received event start for container 5c6cb0bf8e05        

What is the benefit of adding `server 127.0.0.1 down` to upstream at all ?
What is 127.0.0.1 if it isn't it the *nginx container itself* ?        
How can *nginx itself* it be an upstream at all ?

It seems like this patch fixes errors like:

```
nginx.1    | 2019/07/13 02:19:18 [emerg] 30#30: invalid number of arguments in "upstream" directive in /etc/nginx/conf.d/default.conf:54
forego     | starting nginx.1 on port 5200
forego     | sending SIGTERM to nginx.1
forego     | sending SIGTERM to dockergen.1
forego     | starting dockergen.1 on port 5000
forego     | starting nginx.1 on port 5100
nginx.1    | 2019/07/13 02:19:22 [emerg] 27#27: invalid number of arguments in "upstream" directive in /etc/nginx/conf.d/default.conf:54
forego     | starting nginx.1 on port 5200
forego     | sending SIGTERM to nginx.1
forego     | sending SIGTERM to dockergen.1
forego     | starting dockergen.1 on port 5000
forego     | starting nginx.1 on port 5100
nginx.1    | 2019/07/13 02:19:29 [emerg] 28#28: invalid number of arguments in "upstream" directive in /etc/nginx/conf.d/default.conf:54
forego     | starting nginx.1 on port 5200
forego     | sending SIGTERM to nginx.1
forego     | sending SIGTERM to dockergen.1

13/07 2019 04:19:40 jpic@aoeu ~/.ansible/roles/yourlabs.drone  (master)
$ docker ps
CONTAINER ID        IMAGE                        COMMAND                  CREATED             STATUS                          PORTS               NAMES
ee921916195d        jwilder/nginx-proxy:alpine   "/app/docker-entrypo…"   46 seconds ago      Restarting (0) 14 seconds ago                       nginx
```

Related user comments found in:

Related: #1132 #1106
Comments (not OP) of: #375
Maybe: #1144 

Keep up the great work :heart: 