### PR TITLE
support nginx_* env variables on nginx container and vhosts

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -191,6 +191,12 @@ log_format vhost '$host $remote_addr - $remote_user [$time_local] '
 
 access_log off;
 
+{{ range $key, $val := .Env }}
+{{ if and $val (hasPrefix "nginx_" (toLower $key)) }}
+{{ trimPrefix "nginx_" (toLower $key) }} {{ $val }};
+{{ end }}
+{{ end }}
+
 {{/* Get the SSL_POLICY defined by this container, falling back to "Mozilla-Intermediate" */}}
 {{ $ssl_policy := or ($.Env.SSL_POLICY) "Mozilla-Intermediate" }}
 {{ template "ssl_policy" (dict "ssl_policy" $ssl_policy) }}
@@ -376,6 +382,12 @@ server {
 	add_header Strict-Transport-Security "{{ trim $hsts }}" always;
 	{{ end }}
 
+	{{ range $key, $val := (first $containers).Env }}
+	{{ if and $val (hasPrefix "nginx_" (toLower $key)) }}
+	{{ trimPrefix "nginx_" (toLower $key) }} {{ $val }};
+	{{ end }}
+	{{ end }}
+
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
 	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
 	{{ else if (exists "/etc/nginx/vhost.d/default") }}
@@ -423,6 +435,12 @@ server {
 	listen [::]:{{ $external_http_port }} {{ $default_server }};
 	{{ end }}
 	{{ $access_log }}
+
+	{{ range $key, $val := (first $containers).Env }}
+	{{ if and $val (hasPrefix "nginx_" (toLower $key)) }}
+	{{ trimPrefix "nginx_" (toLower $key) }} {{ $val }};
+	{{ end }}
+	{{ end }}
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
 	include {{ printf "/etc/nginx/vhost.d/%s" $host }};


### PR DESCRIPTION
Implementation of #1324 feature request. Environment variables starting with `nginx_*` are added as nginx config statements, for example: `nginx_client_max_body_size=30M`. Variables of jwilder/nginx-proxy container are added to the global config, and variables on others containers are added to the respective vhosts.

Example `docker-compose.yml`:

```yaml
version: '2.1'

services:
  nginx:
    image: jwilder/nginx-proxy
    ports:
      - 80:80
      - 443:443
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
    environment:
      nginx_client_max_body_size: 42M

  app:
    image: app
    environment:
      VIRTUAL_HOST: example.com
      nginx_client_max_body_size: 1337M
```

Currently only lower case variables are supported (until jwilder/docker-gen#306 is merged). Also if there is an easy way to merge `Env` dicts from all containers with the same vhost, we should do that, currently `Env` map is taken from the first container for each vhost.