### PR TITLE
Make it possible to serve static files locally with fastcgi upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,25 @@ If you would like to connect to FastCGI backend, set `VIRTUAL_PROTO=fastcgi` on 
 backend container. Your backend container should then listen on a port rather
 than a socket and expose that port.
  
-### FastCGI Filr Root Directory
+### FastCGI File Root Directory
 
-If you use fastcgi,you can set `VIRTUAL_ROOT=xxx`  for your root directory
+If you use fastcgi, you can set `VIRTUAL_ROOT=xxx` for your root directory
 
+### Sending only certain file extensions upstream
+
+You can set `UPSTREAM_EXTENSIONS=xxx` to only send certain extensions upstream.
+The rest of the files will be served locally. If you want to send multiple
+extensions upstream, separate them like this: `UPSTREAM_EXTENSIONS=php|php5`
+
+When doing this, make sure the VIRTUAL_ROOT is also available to this container.
+The easiest way to do this is defining the VOLUME in your upstream container and
+using
+[volumes_from](https://docs.docker.com/compose/compose-file/compose-file-v2/#volumes_from)
+or equivalent.
+
+You likely also want to set `INDEX=xxx` to send non-matching URLs upstream. For
+example, think of an url like /user/login, which won't resolve to a local file,
+but which the upstream fastcgi will understand: `INDEX=index.php`.
 
 ### Default Host
 

--- a/README.md
+++ b/README.md
@@ -137,11 +137,13 @@ than a socket and expose that port.
 
 If you use fastcgi, you can set `VIRTUAL_ROOT=xxx` for your root directory
 
-### Sending only certain file extensions upstream
+### Sending only certain files upstream
 
-You can set `UPSTREAM_EXTENSIONS=xxx` to only send certain extensions upstream.
+You can set `UPSTREAM_REGEXES=xxx` to only send certain requests upstream.
 The rest of the files will be served locally. If you want to send multiple
-extensions upstream, separate them like this: `UPSTREAM_EXTENSIONS=php|php5`
+regexes upstream, separate them like this: `UPSTREAM_REGEXES=/en|.*\.php|.*\.php5`
+
+Above example will send example.com/en and all .php and .php5 files upstream.
 
 When doing this, make sure the VIRTUAL_ROOT is also available to this container.
 The easiest way to do this is defining the VOLUME in your upstream container and

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -220,6 +220,11 @@ upstream {{ $upstream_name }} {
 {{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
 {{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
 
+{{/* Which extensions to send upstream when using fastcgi, if not default, send everything upstream. Make sure the VIRTUAL_ROOT is available to this container when using this */}}
+{{ $vhost_upstream_extensions := trim (or (first (groupByKeys $containers "Env.UPSTREAM_EXTENSIONS")) "") }}
+
+{{/* Which filename to use as index file */}}
+{{ $vhost_index := or (first (groupByKeys $containers "Env.INDEX")) "" }}
 
 {{/* Get the first cert name defined by containers w/ the same vhost */}}
 {{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}
@@ -292,16 +297,50 @@ server {
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
 
-	location / {
+	{{ if $vhost_upstream_extensions }}
+	root {{ trim $vhost_root }};
+	location ~* \.({{ $vhost_upstream_extensions }})$ {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
 		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ else if eq $proto "fastcgi" }}
-		root   {{ trim $vhost_root }};
 		include fastcgi_params;
+		{{ if $vhost_index }}
+		fastcgi_param SCRIPT_FILENAME $document_root/{{ $vhost_index }};
+		{{ end }}
 		fastcgi_pass {{ trim $upstream_name }};
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		{{ end }}
+
+		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+		auth_basic	"Restricted {{ $host }}";
+		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+		{{ end }}
+		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
+		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+		include /etc/nginx/vhost.d/default_location;
+		{{ end }}
+	}
+	{{ end }}
+	location / {
+		{{ if not $vhost_upstream_extensions }}
+			{{ if eq $proto "uwsgi" }}
+			include uwsgi_params;
+			uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
+			{{ else if eq $proto "fastcgi" }}
+			include fastcgi_params;
+			{{ if $vhost_index }}
+			fastcgi_param SCRIPT_FILENAME $document_root/{{ $vhost_index }};
+			{{ end }}
+			fastcgi_pass {{ trim $upstream_name }};
+			{{ else }}
+			proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+			{{ end }}
+		{{ else if $vhost_index }}
+			index {{ $vhost_index }};
+			try_files $uri $uri/ /{{ $vhost_index }};
 		{{ end }}
 
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
@@ -339,17 +378,52 @@ server {
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
 
-	location / {
+	{{ if $vhost_upstream_extensions }}
+	root {{ trim $vhost_root }};
+	location ~* \.({{ $vhost_upstream_extensions }})$ {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
 		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ else if eq $proto "fastcgi" }}
-		root   {{ trim $vhost_root }};
 		include fastcgi_params;
+		{{ if $vhost_index }}
+		fastcgi_param SCRIPT_FILENAME $document_root/{{ $vhost_index }};
+		{{ end }}
 		fastcgi_pass {{ trim $upstream_name }};
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}
+
+		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+		auth_basic	"Restricted {{ $host }}";
+		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+		{{ end }}
+		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
+		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+		include /etc/nginx/vhost.d/default_location;
+		{{ end }}
+	}
+	{{ end }}
+	location / {
+		{{ if not $vhost_upstream_extensions }}
+			{{ if eq $proto "uwsgi" }}
+			include uwsgi_params;
+			uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
+			{{ else if eq $proto "fastcgi" }}
+			include fastcgi_params;
+			{{ if $vhost_index }}
+			fastcgi_param SCRIPT_FILENAME $document_root/{{ $vhost_index }};
+			{{ end }}
+			fastcgi_pass {{ trim $upstream_name }};
+			{{ else }}
+			proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+			{{ end }}
+		{{ else if $vhost_index }}
+			index {{ $vhost_index }};
+			try_files $uri $uri/ /{{ $vhost_index }};
+		{{ end }}
+
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -220,8 +220,8 @@ upstream {{ $upstream_name }} {
 {{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
 {{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
 
-{{/* Which extensions to send upstream when using fastcgi, if not default, send everything upstream. Make sure the VIRTUAL_ROOT is available to this container when using this */}}
-{{ $vhost_upstream_extensions := trim (or (first (groupByKeys $containers "Env.UPSTREAM_EXTENSIONS")) "") }}
+{{/* Which regexes when matching to send upstream when using fastcgi. If not defined, send everything upstream. Make sure the VIRTUAL_ROOT is available to this container when using this */}}
+{{ $vhost_upstream_regexes := trim (or (first (groupByKeys $containers "Env.UPSTREAM_REGEXES")) "") }}
 
 {{/* Which filename to use as index file */}}
 {{ $vhost_index := or (first (groupByKeys $containers "Env.INDEX")) "" }}
@@ -297,9 +297,9 @@ server {
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
 
-	{{ if $vhost_upstream_extensions }}
+	{{ if $vhost_upstream_regexes }}
 	root {{ trim $vhost_root }};
-	location ~* \.({{ $vhost_upstream_extensions }})$ {
+	location ~* "^({{ $vhost_upstream_regexes }})$" {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
 		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
@@ -325,7 +325,7 @@ server {
 	}
 	{{ end }}
 	location / {
-		{{ if not $vhost_upstream_extensions }}
+		{{ if not $vhost_upstream_regexes }}
 			{{ if eq $proto "uwsgi" }}
 			include uwsgi_params;
 			uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
@@ -378,9 +378,9 @@ server {
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
 
-	{{ if $vhost_upstream_extensions }}
+	{{ if $vhost_upstream_regexes }}
 	root {{ trim $vhost_root }};
-	location ~* \.({{ $vhost_upstream_extensions }})$ {
+	location ~* "^({{ $vhost_upstream_regexes }})$" {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
 		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
@@ -406,7 +406,7 @@ server {
 	}
 	{{ end }}
 	location / {
-		{{ if not $vhost_upstream_extensions }}
+		{{ if not $vhost_upstream_regexes }}
 			{{ if eq $proto "uwsgi" }}
 			include uwsgi_params;
 			uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -340,7 +340,7 @@ server {
 			{{ end }}
 		{{ else if $vhost_index }}
 			index {{ $vhost_index }};
-			try_files $uri $uri/ /{{ $vhost_index }};
+			try_files $uri $uri/ /{{ $vhost_index }}?$query_string;
 		{{ end }}
 
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
@@ -421,7 +421,7 @@ server {
 			{{ end }}
 		{{ else if $vhost_index }}
 			index {{ $vhost_index }};
-			try_files $uri $uri/ /{{ $vhost_index }};
+			try_files $uri $uri/ /{{ $vhost_index }}?$query_string;
 		{{ end }}
 
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}


### PR DESCRIPTION
The idea of this pull request is to allow only sending a chosen list of extensions upstream, so that this container could serve static files itself and only make upstream (PHP-FPM for example) deal with the non-static files.

I have only tested this with fastcgi and PHP-FPM as upstream, but it works quite well here.