### PR TITLE
Add VIRTUAL_PATH and VIRTUAL_PATH_STRIP to run reverse-proxy as LB/proxy for pool of services

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -297,16 +297,34 @@ server {
 	{{ $is_regexp := hasPrefix "^" $location }}
 	{{ $modifier := when $is_regexp "~" "" }}
 
+	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
 	location {{ $modifier }} '{{ $location }}' {
+		return 302 '{{ $location }}/';
+	}
+	{{ end }}
+
+	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+	location {{ $modifier }} '{{ $location }}/' {
+	{{ else }}
+	location {{ $modifier }} '{{ $location }}' {
+	{{ end }}
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
+		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }}/;
+		{{ else }}
 		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }};
+		{{ end }}
 		{{ else if eq $proto "fastcgi" }}
 		root   {{ trim $vhost_root }};
 		include fastcgi_params;
 		fastcgi_pass {{ trim $container.Name }};
 		{{ else }}
+		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+		proxy_pass {{ trim $proto }}://{{ trim $container.Name }}/;
+		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $container.Name }};
+		{{ end }}
 		{{ end }}
 
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
@@ -352,16 +370,34 @@ server {
 	{{ $is_regexp := hasPrefix "^" $location }}
 	{{ $modifier := when $is_regexp "~" "" }}
 
+	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
 	location {{ $modifier }} '{{ $location }}' {
+		return 302 '{{ $location }}/';
+	}
+	{{ end }}
+
+	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+	location {{ $modifier }} '{{ $location }}/' {
+	{{ else }}
+	location {{ $modifier }} '{{ $location }}' {
+	{{ end }}
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
+		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }}/;
+		{{ else }}
 		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }};
+		{{ end }}
 		{{ else if eq $proto "fastcgi" }}
 		root   {{ trim $vhost_root }};
 		include fastcgi_params;
 		fastcgi_pass {{ trim $container.Name }};
 		{{ else }}
+		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+		proxy_pass {{ trim $proto }}://{{ trim $container.Name }}/;
+		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $container.Name }};
+		{{ end }}
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -294,7 +294,10 @@ server {
 	{{ range $container := $containers }}
 	{{/* Determine whether this container has specified a virtual path, or default to the / pattern */}}
 	{{ $location := coalesce $container.Env.VIRTUAL_PATH "/" }}
-	location {{ $location }} {
+	{{ $is_regexp := hasPrefix "^" $location }}
+	{{ $modifier := when $is_regexp "~" "" }}
+
+	location {{ $modifier }} '{{ $location }}' {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
 		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }};
@@ -346,7 +349,10 @@ server {
 	{{/* Determine whether this container has specified a virtual path, or default to the / pattern */}}
 	{{ $location := coalesce $container.Env.VIRTUAL_PATH "/" }}
 
-	location {{ $location }} {
+	{{ $is_regexp := hasPrefix "^" $location }}
+	{{ $modifier := when $is_regexp "~" "" }}
+
+	location {{ $modifier }} '{{ $location }}' {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
 		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }};

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -297,20 +297,20 @@ server {
 	{{ $is_regexp := hasPrefix "^" $location }}
 	{{ $modifier := when $is_regexp "~" "" }}
 
-	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
 	location {{ $modifier }} '{{ $location }}' {
 		return 302 '{{ $location }}/';
 	}
 	{{ end }}
 
-	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
 	location {{ $modifier }} '{{ $location }}/' {
 	{{ else }}
 	location {{ $modifier }} '{{ $location }}' {
 	{{ end }}
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
-		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
 		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }}/;
 		{{ else }}
 		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }};
@@ -320,7 +320,7 @@ server {
 		include fastcgi_params;
 		fastcgi_pass {{ trim $container.Name }};
 		{{ else }}
-		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
 		proxy_pass {{ trim $proto }}://{{ trim $container.Name }}/;
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $container.Name }};
@@ -370,20 +370,20 @@ server {
 	{{ $is_regexp := hasPrefix "^" $location }}
 	{{ $modifier := when $is_regexp "~" "" }}
 
-	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
 	location {{ $modifier }} '{{ $location }}' {
 		return 302 '{{ $location }}/';
 	}
 	{{ end }}
 
-	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
 	location {{ $modifier }} '{{ $location }}/' {
 	{{ else }}
 	location {{ $modifier }} '{{ $location }}' {
 	{{ end }}
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
-		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
 		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }}/;
 		{{ else }}
 		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }};
@@ -393,7 +393,7 @@ server {
 		include fastcgi_params;
 		fastcgi_pass {{ trim $container.Name }};
 		{{ else }}
-		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "TRUE") }}
+		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
 		proxy_pass {{ trim $proto }}://{{ trim $container.Name }}/;
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $container.Name }};

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -297,20 +297,20 @@ server {
 	{{ $is_regexp := hasPrefix "^" $location }}
 	{{ $modifier := when $is_regexp "~" "" }}
 
-	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
+	{{ if (eq (or ($container.Env.VIRTUAL_PATH_STRIP) "") "true") }}
 	location {{ $modifier }} '{{ $location }}' {
 		return 302 '{{ $location }}/';
 	}
 	{{ end }}
 
-	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
+	{{ if (eq (or ($container.Env.VIRTUAL_PATH_STRIP) "") "true") }}
 	location {{ $modifier }} '{{ $location }}/' {
 	{{ else }}
 	location {{ $modifier }} '{{ $location }}' {
 	{{ end }}
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
-		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
+		{{ if (eq (or ($container.Env.VIRTUAL_PATH_STRIP) "") "true") }}
 		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }}/;
 		{{ else }}
 		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }};
@@ -320,7 +320,7 @@ server {
 		include fastcgi_params;
 		fastcgi_pass {{ trim $container.Name }};
 		{{ else }}
-		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
+		{{ if (eq (or ($container.Env.VIRTUAL_PATH_STRIP) "") "true") }}
 		proxy_pass {{ trim $proto }}://{{ trim $container.Name }}/;
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $container.Name }};
@@ -370,20 +370,20 @@ server {
 	{{ $is_regexp := hasPrefix "^" $location }}
 	{{ $modifier := when $is_regexp "~" "" }}
 
-	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
+	{{ if (eq (or ($container.Env.VIRTUAL_PATH_STRIP) "") "true") }}
 	location {{ $modifier }} '{{ $location }}' {
 		return 302 '{{ $location }}/';
 	}
 	{{ end }}
 
-	{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
+	{{ if (eq (or ($container.Env.VIRTUAL_PATH_STRIP) "") "true") }}
 	location {{ $modifier }} '{{ $location }}/' {
 	{{ else }}
 	location {{ $modifier }} '{{ $location }}' {
 	{{ end }}
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
-		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
+		{{ if (eq (or ($container.Env.VIRTUAL_PATH_STRIP) "") "true") }}
 		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }}/;
 		{{ else }}
 		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }};
@@ -393,7 +393,7 @@ server {
 		include fastcgi_params;
 		fastcgi_pass {{ trim $container.Name }};
 		{{ else }}
-		{{ if (eq $container.Env.VIRTUAL_PATH_STRIP "true") }}
+		{{ if (eq (or ($container.Env.VIRTUAL_PATH_STRIP) "") "true") }}
 		proxy_pass {{ trim $proto }}://{{ trim $container.Name }}/;
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $container.Name }};

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -169,10 +169,9 @@ server {
 {{ $is_regexp := hasPrefix "~" $host }}
 {{ $upstream_name := when $is_regexp (sha1 $host) $host }}
 
-# {{ $host }}
-upstream {{ $upstream_name }} {
-
 {{ range $container := $containers }}
+# {{ $container.Name }}
+upstream {{ $container.Name }} {
 	{{ $addrLen := len $container.Addresses }}
 
 	{{ range $knownNetwork := $CurrentContainer.Networks }}
@@ -196,8 +195,8 @@ upstream {{ $upstream_name }} {
 			{{ end }}
 		{{ end }}
 	{{ end }}
-{{ end }}
 }
+{{ end }}
 
 {{ $default_host := or ($.Env.DEFAULT_HOST) "" }}
 {{ $default_server := index (dict $host "" $default_host "default_server") $host }}
@@ -292,16 +291,19 @@ server {
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
 
-	location / {
+	{{ range $container := $containers }}
+	{{/* Determine whether this container has specified a virtual path, or default to the / pattern */}}
+	{{ $location := coalesce $container.Env.VIRTUAL_PATH "/" }}
+	location {{ $location }} {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }};
 		{{ else if eq $proto "fastcgi" }}
 		root   {{ trim $vhost_root }};
 		include fastcgi_params;
-		fastcgi_pass {{ trim $upstream_name }};
+		fastcgi_pass {{ trim $container.Name }};
 		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		proxy_pass {{ trim $proto }}://{{ trim $container.Name }};
 		{{ end }}
 
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
@@ -314,6 +316,7 @@ server {
 		include /etc/nginx/vhost.d/default_location;
 		{{ end }}
 	}
+	{{ end }} 
 }
 
 {{ end }}
@@ -339,16 +342,20 @@ server {
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
 
-	location / {
+	{{ range $container := $containers }}
+	{{/* Determine whether this container has specified a virtual path, or default to the / pattern */}}
+	{{ $location := coalesce $container.Env.VIRTUAL_PATH "/" }}
+
+	location {{ $location }} {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }};
 		{{ else if eq $proto "fastcgi" }}
 		root   {{ trim $vhost_root }};
 		include fastcgi_params;
-		fastcgi_pass {{ trim $upstream_name }};
+		fastcgi_pass {{ trim $container.Name }};
 		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		proxy_pass {{ trim $proto }}://{{ trim $container.Name }};
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
@@ -360,6 +367,8 @@ server {
 		include /etc/nginx/vhost.d/default_location;
 		{{ end }}
 	}
+
+	{{ end }}
 }
 
 {{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}


### PR DESCRIPTION
Rebased #1257 and new feature that removes the incorrect behavior if the service expects deployment on the domain directly and under root (`/`) path.

Without stripping requests fail because the `VIRTUAL_PATH` is propagated into the service and service might not be created with such behavior in mind. Pretty much none of big projects nowadays because everyone wants separate DNS record that gets translated into `Host` for nginx to route :grimacing:.

Example:

    # accessing directly VIRTUAL_PATH with stripping
    GET /service  (nginx uses 302 to bump to the correct location)
    GET /service/ (nginx allows communication with container)
    GET /         (the request as visible within the service container)

    # accessing VIRTUAL_PATH without stripping
    GET /service  (nginx routes traffic directly to container)
    GET /service  (the request as visible within the service container)
    404/500/...   (service rejects request because can't handle path prefix)

Tests such as https://github.com/jwilder/nginx-proxy/blob/e7624687599a44a09b23e79c7fc8c614778eabae/test/test_multiple-hosts.py#L5 were failing, but it seems to be wrong anyway since port should be written with a colon (`:`) because the slash (`/`) is a part of a location/route for nginx.

Testing Alpine image available [on Docker Hub](https://hub.docker.com/repository/docker/keyweeusr/nginx-proxy).