### PR TITLE
Add fallback to the proxy containers env for HTTPS_METHOD and HSTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ a 500.
 To serve traffic in both SSL and non-SSL modes without redirecting to SSL, you can include the
 environment variable `HTTPS_METHOD=noredirect` (the default is `HTTPS_METHOD=redirect`).  You can also
 disable the non-SSL site entirely with `HTTPS_METHOD=nohttp`, or disable the HTTPS site with
-`HTTPS_METHOD=nohttps`. `HTTPS_METHOD` must be specified on each container for which you want to
-override the default behavior.  If `HTTPS_METHOD=noredirect` is used, Strict Transport Security (HSTS)
+`HTTPS_METHOD=nohttps`. `HTTPS_METHOD` can be specified on each container for which you want to
+override the default behavior or on the proxy container to set it globally. If `HTTPS_METHOD=noredirect` is used, Strict Transport Security (HSTS)
 is disabled to prevent HTTPS users from being redirected by the client.  If you cannot get to the HTTP
 site after changing this setting, your browser has probably cached the HSTS policy and is automatically
 redirecting you back to HTTPS.  You will need to clear your browser's HSTS cache or use an incognito

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -209,13 +209,13 @@ upstream {{ $upstream_name }} {
 {{ $network_tag := or (first (groupByKeys $containers "Env.NETWORK_ACCESS")) "external" }}
 
 {{/* Get the HTTPS_METHOD defined by containers w/ the same vhost, falling back to "redirect" */}}
-{{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) "redirect" }}
+{{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) (or $.Env.HTTPS_METHOD "redirect") }}
 
 {{/* Get the SSL_POLICY defined by containers w/ the same vhost, falling back to empty string (use default) */}}
 {{ $ssl_policy := or (first (groupByKeys $containers "Env.SSL_POLICY")) "" }}
 
 {{/* Get the HSTS defined by containers w/ the same vhost, falling back to "max-age=31536000" */}}
-{{ $hsts := or (first (groupByKeys $containers "Env.HSTS")) "max-age=31536000" }}
+{{ $hsts := or (first (groupByKeys $containers "Env.HSTS")) (or $.Env.HSTS "max-age=31536000") }}
 
 {{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
 {{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}


### PR DESCRIPTION
The current implementation requires each container to set the `HTTPS_METHOD` and `HSTS` environment variable individually. This pr adds an intermediate fallback to allow setting the value also on the main nginx-proxy container. If they are not set, the default will be the same as before.