### PR TITLE
Fix dhparam parsing error

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,7 +17,7 @@ fi
 # Generate dhparam file if required
 # Note: if $DHPARAM_BITS is not defined, generate-dhparam.sh will use 2048 as a default
 # Note2: if $DHPARAM_GENERATION is set to false in environment variable, dh param generator will skip completely
-/app/generate-dhparam.sh $DHPARAM_BITS $DHPARAM_GENERATION
+/app/generate-dhparam.sh ${DHPARAM_BITS:-2048} $DHPARAM_GENERATION
 
 # Compute the DNS resolvers for use in the templates - if the IP contains ":", it's IPv6 and must be enclosed in []
 export RESOLVERS=$(awk '$1 == "nameserver" {print ($2 ~ ":")? "["$2"]": $2}' ORS=' ' /etc/resolv.conf | sed 's/ *$//g')


### PR DESCRIPTION
Parsing error raised when DHPARAM_BITS is blank. Fix by setting default value for DHPARAM_BITS to avoid DHPARAM_GENERATION to be send as first argument of generate-dhparam.sh