### PR TITLE
Bring ACME no redirection inline with companion

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -251,8 +251,9 @@ server {
 	access_log /var/log/nginx/access.log vhost;
 	
 	# Do not HTTPS redirect Let'sEncrypt ACME challenge
-	location /.well-known/acme-challenge/ {
+	location ^~ /.well-known/acme-challenge/ {
 		auth_basic off;
+		auth_request off;
 		allow all;
 		root /usr/share/nginx/html;
 		try_files $uri =404;


### PR DESCRIPTION
Add the following to the Let's Encrypt ACME challenge "no redirection to HTTPS"

https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/pull/570
https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion/pull/335