### PR TITLE
Imrove acme-challenge handling

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -239,9 +239,14 @@ upstream {{ $upstream_name }} {
 {{/* Use the cert specified on the container or fallback to the best vhost match */}}
 {{ $cert := (coalesce $certName $vhostCert) }}
 
-{{ $is_https := (and (ne $https_method "nohttps") (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
+{{ $is_https := (ne $https_method "nohttps") }}
 
 {{ if $is_https }}
+{{/* No cert? But we do want HTTPS! Let's fallback on the nginx default one.
+     And set up acme-challenge so that Let's Encrpyt can do its job */}}
+{{ $cert := coalesce $cert "default" }}
+{{/* Very same reasoning as above */}}
+{{ $cert := when (and (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) $cert "default" }}
 
 {{ if eq $https_method "redirect" }}
 server {


### PR DESCRIPTION
so that there is no need anomyre for the Let's Encrypt companion to fiddle
with vhosts nginx configuration.