### PR TITLE
Enable multi-architecture docker image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,50 @@
-FROM nginx:1.19.3
+# setup build arguments for version of dependencies to use
+ARG NGINX_VERSION=1.19.3
+ARG GO_VERSION=1.14
+
+ARG DOCKER_GEN_VERSION=0.7.4
+ARG FOREGO_VERSION=0.16.1
+
+# Use a specific version of golang to build both binaries
+FROM golang:$GO_VERSION as gobuilder
+
+# Build docker-gen from scratch
+FROM gobuilder as dockergen
+
+# Download the sources for the given version
+ARG DOCKER_GEN_VERSION
+ADD https://github.com/jwilder/docker-gen/archive/${DOCKER_GEN_VERSION}.tar.gz sources.tar.gz
+
+# Move the sources into the right directory
+RUN tar -xzf sources.tar.gz && \
+   mkdir -p /go/src/github.com/jwilder/ && \
+   mv docker-gen-* /go/src/github.com/jwilder/docker-gen
+
+# Install the dependencies and make the docker-gen executable
+WORKDIR /go/src/github.com/jwilder/docker-gen
+RUN go get -v ./... && \
+   CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.buildVersion=${DOCKER_GEN_VERSION}" ./cmd/docker-gen
+
+# Build forego from scratch
+# Because this relies on golang workspaces, we need to use go < 1.8. 
+FROM gobuilder as forego
+
+# Download the sources for the given version
+ARG FOREGO_VERSION
+ADD https://github.com/jwilder/forego/archive/v${FOREGO_VERSION}.tar.gz sources.tar.gz
+
+# Move the sources into the right directory
+RUN tar -xzf sources.tar.gz && \
+   mkdir -p /go/src/github.com/ddollar/ && \
+   mv forego-* /go/src/github.com/ddollar/forego
+
+# Install the dependencies and make the forego executable
+WORKDIR /go/src/github.com/ddollar/forego/
+RUN go get -v ./... && \
+   CGO_ENABLED=0 GOOS=linux go build -o forego .
+
+# Build the final image
+FROM nginx:$NGINX_VERSION
 LABEL maintainer="Jason Wilder mail@jasonwilder.com"
 
 # Install wget and install/updates certificates
@@ -14,15 +60,14 @@ RUN apt-get update \
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf
 
-# Install Forego
-ADD https://github.com/jwilder/forego/releases/download/v0.16.1/forego /usr/local/bin/forego
-RUN chmod u+x /usr/local/bin/forego
+# Install Forego + docker-gen
+COPY --from=forego /go/src/github.com/ddollar/forego/forego /usr/local/bin/forego
+COPY --from=dockergen /go/src/github.com/jwilder/docker-gen/docker-gen /usr/local/bin/docker-gen
 
-ENV DOCKER_GEN_VERSION 0.7.4
-
-RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
- && tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
- && rm /docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
+# Add DOCKER_GEN_VERSION environment variable
+# Because some external projects rely on it
+ARG DOCKER_GEN_VERSION
+ENV DOCKER_GEN_VERSION=${DOCKER_GEN_VERSION}
 
 COPY network_internal.conf /etc/nginx/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
 # setup build arguments for version of dependencies to use
-ARG NGINX_VERSION=1.19.3
-
 ARG DOCKER_GEN_VERSION=0.7.4
 ARG FOREGO_VERSION=0.16.1
 
@@ -43,7 +41,7 @@ RUN go get -v ./... && \
    CGO_ENABLED=0 GOOS=linux go build -o forego .
 
 # Build the final image
-FROM nginx:$NGINX_VERSION
+FROM nginx:1.19.3
 LABEL maintainer="Jason Wilder mail@jasonwilder.com"
 
 # Install wget and install/updates certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 # setup build arguments for version of dependencies to use
 ARG NGINX_VERSION=1.19.3
-ARG GO_VERSION=1.14
 
 ARG DOCKER_GEN_VERSION=0.7.4
 ARG FOREGO_VERSION=0.16.1
 
 # Use a specific version of golang to build both binaries
-FROM golang:$GO_VERSION as gobuilder
+FROM golang:1.15.10 as gobuilder
 
 # Build docker-gen from scratch
 FROM gobuilder as dockergen

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,51 @@
-FROM nginx:1.19.3-alpine
+# setup build arguments for version of dependencies to use
+ARG NGINX_VERSION=1.19.3-alpine
+ARG GO_VERSION=1.14-alpine
+
+ARG DOCKER_GEN_VERSION=0.7.4
+ARG FOREGO_VERSION=0.16.1
+
+# Use a specific version of golang to build both binaries
+FROM golang:$GO_VERSION as gobuilder
+RUN apk add --no-cache git
+
+# Build docker-gen from scratch
+FROM gobuilder as dockergen
+
+# Download the sources for the given version
+ARG DOCKER_GEN_VERSION
+ADD https://github.com/jwilder/docker-gen/archive/${DOCKER_GEN_VERSION}.tar.gz sources.tar.gz
+
+# Move the sources into the right directory
+RUN tar -xzf sources.tar.gz && \
+   mkdir -p /go/src/github.com/jwilder/ && \
+   mv docker-gen-* /go/src/github.com/jwilder/docker-gen
+
+# Install the dependencies and make the docker-gen executable
+WORKDIR /go/src/github.com/jwilder/docker-gen
+RUN go get -v ./... && \
+   CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.buildVersion=${DOCKER_GEN_VERSION}" ./cmd/docker-gen
+
+# Build forego from scratch
+# Because this relies on golang workspaces, we need to use go < 1.8. 
+FROM gobuilder as forego
+
+# Download the sources for the given version
+ARG FOREGO_VERSION
+ADD https://github.com/jwilder/forego/archive/v${FOREGO_VERSION}.tar.gz sources.tar.gz
+
+# Move the sources into the right directory
+RUN tar -xzf sources.tar.gz && \
+   mkdir -p /go/src/github.com/ddollar/ && \
+   mv forego-* /go/src/github.com/ddollar/forego
+
+# Install the dependencies and make the forego executable
+WORKDIR /go/src/github.com/ddollar/forego/
+RUN go get -v ./... && \
+   CGO_ENABLED=0 GOOS=linux go build -o forego .
+
+# Build the final image
+FROM nginx:$NGINX_VERSION
 LABEL maintainer="Jason Wilder mail@jasonwilder.com"
 
 # Install wget and install/updates certificates
@@ -11,15 +58,14 @@ RUN apk add --no-cache --virtual .run-deps \
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf
 
-# Install Forego
-ADD https://github.com/jwilder/forego/releases/download/v0.16.1/forego /usr/local/bin/forego
-RUN chmod u+x /usr/local/bin/forego
+# Install Forego + docker-gen
+COPY --from=forego /go/src/github.com/ddollar/forego/forego /usr/local/bin/forego
+COPY --from=dockergen /go/src/github.com/jwilder/docker-gen/docker-gen /usr/local/bin/docker-gen
 
-ENV DOCKER_GEN_VERSION 0.7.4
-
-RUN wget --quiet https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
- && tar -C /usr/local/bin -xvzf docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
- && rm /docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
+# Add DOCKER_GEN_VERSION environment variable
+# Because some external projects rely on it
+ARG DOCKER_GEN_VERSION
+ENV DOCKER_GEN_VERSION=${DOCKER_GEN_VERSION}
 
 COPY network_internal.conf /etc/nginx/
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,4 @@
 # setup build arguments for version of dependencies to use
-ARG NGINX_VERSION=1.19.3-alpine
-
 ARG DOCKER_GEN_VERSION=0.7.4
 ARG FOREGO_VERSION=0.16.1
 
@@ -44,7 +42,7 @@ RUN go get -v ./... && \
    CGO_ENABLED=0 GOOS=linux go build -o forego .
 
 # Build the final image
-FROM nginx:$NGINX_VERSION
+FROM nginx:1.19.3-alpine
 LABEL maintainer="Jason Wilder mail@jasonwilder.com"
 
 # Install wget and install/updates certificates

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,12 +1,11 @@
 # setup build arguments for version of dependencies to use
 ARG NGINX_VERSION=1.19.3-alpine
-ARG GO_VERSION=1.14-alpine
 
 ARG DOCKER_GEN_VERSION=0.7.4
 ARG FOREGO_VERSION=0.16.1
 
 # Use a specific version of golang to build both binaries
-FROM golang:$GO_VERSION as gobuilder
+FROM golang:1.15.10-alpine as gobuilder
 RUN apk add --no-cache git
 
 # Build docker-gen from scratch


### PR DESCRIPTION
Previously, the Dockerfile downloaded 'docker-gen' and 'forego' binaries during build time. This caused a problem as it hard-coded the amd64 architecture for the images.

This PR updates both 'Dockerfile' and 'Dockerfile.alpine' to build the `forego` and `docker-gen` executables from source instead of downloading binaries directly. This is achieved using multi-stage builds [1]. Two separate stages first build the binaries, and are then copied over to the final stage.

The advantage of this change is two-fold: First, it enables building this image on architectures other than amd64. Second it adds trust by not adding external binaries to the docker image.

This modified version passes the tests both a linux desktop (`amd64`) as well as a raspberry pi (`armv7`) with some caveats:

- On `armv7`, a modified version of the `jwilder/docker-gen` image is required. See jwilder/docker-gen#327. 
- The `test_dhparam_is_generated_if_missing` test fails. This also doesn't currently pass on master. See #1468. 

See also:
- #1317 and #1370, #1297: These issues request an arm version of the image. Together with publishing arm images on DockerHub, this PR should fix all of them. 
- #1262, #1071: Both these PRs make a separate Dockerfile for the arm architecture. This PR is more general, in that it doesn't assume a specific architecture. In particular any architecture supported by the golang, debian and alpine base images can be used. 

[1] https://docs.docker.com/develop/develop-images/multistage-build/