### PR TITLE
Support no Docker proxy by env VIRTUAL_UPSTREAM

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -178,6 +178,13 @@ server {
 upstream {{ $upstream_name }} {
 
 {{ range $container := $containers }}
+{{ $upstreams := or ($container.Env.VIRTUAL_UPSTREAM) "" }}
+{{ if ne $upstreams "" }}
+	# connect to extern VIRTUAL_UPSTREAM
+	{{ range $upstream := split $upstreams "," }}
+	server {{ $upstream }};
+	{{ end }}
+{{ else }}
 	{{ $addrLen := len $container.Addresses }}
 
 	{{ range $knownNetwork := $CurrentContainer.Networks }}
@@ -201,6 +208,7 @@ upstream {{ $upstream_name }} {
 			{{ end }}
 		{{ end }}
 	{{ end }}
+{{ end }}
 {{ end }}
 }
 


### PR DESCRIPTION
If set env as below:

```
VIRTUAL_HOST=foo.example.com
VIRTUAL_UPSTREAM=192.168.1.8:8080,192.168.1.9:80 down
```

The default.conf's upstream sections is:

```
upstream foo.example.com {
    server 192.168.1.8:8080;
    server 192.168.1.9:80 down;
} 
```

VIRTUAL_HOST and VIRTUAL_UPSTREAM can be used in nginx-proxy container or any other fake container.

VIRTUAL_HOST do not support multiple hosts.
VIRTUAL_UPSTREAM support multiple address and deli with comma ','.