### PR TITLE
Add support for 'CUSTOM_LOG_FORMAT' env var

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -105,9 +105,13 @@ map $scheme $proxy_x_forwarded_ssl {
 
 gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
+{{ if $.Env.CUSTOM_LOG_FORMAT }}
+log_format vhost '{{ $.Env.CUSTOM_LOG_FORMAT }}';
+{{ else }}
 log_format vhost '$host $remote_addr - $remote_user [$time_local] '
                  '"$request" $status $body_bytes_sent '
                  '"$http_referer" "$http_user_agent"';
+{{ end }}
 
 access_log off;
 


### PR DESCRIPTION
This modification allows you to customize log format with CUSTOM_LOG_FORMAT env var.

With docker-compose.yml, you can set CUSTOM_LOG_FORMAT like as below:

```
    environment:
      - CUSTOM_LOG_FORMAT=$$host $$remote_addr - $$remote_user [$$time_local] "$$request" $$status $$body_bytes_sent "$$http_referer" "$$http_user_agent" "$$http_x_forwarded_for"
```

This make "log_format vhost" line in defaults.conf as below:

```
log_format vhost '$host $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
```
