### PR TITLE
Supply max_fails=0 on all server entries

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -9,16 +9,16 @@
 		{{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
 		{{ if and .Container.Node.ID .Address.HostPort }}
 	# {{ .Container.Node.Name }}/{{ .Container.Name }}
-			server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }};
+	server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }} max_fails=0;
 		{{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
 		{{ else if .Network }}
 	# {{ .Container.Name }}
-	server {{ .Network.IP }}:{{ .Address.Port }};
+	server {{ .Network.IP }}:{{ .Address.Port }} max_fails=0;
 		{{ end }}
 	{{ else if .Network }}
 	# {{ .Container.Name }}
 		{{ if .Network.IP }}
-	server {{ .Network.IP }}:{{ .VirtualPort }};
+	server {{ .Network.IP }}:{{ .VirtualPort }} max_fails=0;
 		{{ else }}
 	# /!\ No IP for this network!
 		{{ end }}

--- a/test/test_multiple-ports/test_VIRTUAL_PORT-single-different-from-single-port.py
+++ b/test/test_multiple-ports/test_VIRTUAL_PORT-single-different-from-single-port.py
@@ -5,4 +5,4 @@ import re
 def test_answer_is_served_from_virtual_port_which_is_ureachable(docker_compose, nginxproxy):
     r = nginxproxy.get("http://web.nginx-proxy.tld/port")
     assert r.status_code == 502
-    assert re.search(r"\n\s+server \d+\.\d+\.\d+\.\d+:90;\n", nginxproxy.get_conf().decode('ASCII'))
+    assert re.search(r"\n\s+server \d+\.\d+\.\d+\.\d+:90 max_fails=0;\n", nginxproxy.get_conf().decode('ASCII'))


### PR DESCRIPTION
If nginx-proxy is run on a host whose docker config has multiple
networks, then it will generate an additional

  server XXX down;

entry in each upstream for networks on which the container _isn't_.
Having more than one server entry in an upstream invokes nginx's
max_fails/fail_timeout behavior, which will mark the only live
upstream server as down for 10s if it returns ONE error response.

Instead, we want nginx to keep retrying the live upstream server
regardless of what it returns, since there's nothing else to try.
Passing "max_fails=0" on each live server entry disables the
max_fails/fail_timeout behavior.

Fixes #1495.