### PR TITLE
Nginx-Logs upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,12 @@ COPY . /app/
 WORKDIR /app/
 
 ENV DOCKER_HOST unix:///tmp/docker.sock
+ENV TERM xterm-mono
+ENV force_color_prompt no
 
-VOLUME ["/etc/nginx/certs", "/etc/nginx/dhparam"]
+VOLUME ["/etc/nginx/certs", "/etc/nginx/dhparam", "/var/logs/nginx"]
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["forego", "start", "-r"]


### PR DESCRIPTION
Hello,

I have made an upgrade of the nginx-proxy Dockerfile in order to move access logs and error logs out of the container, in a volume mounted from remote host, so that a log collecting tool can easily be placed to setup a monitoring stack such as datadog or kibana

i have tested this successfully with filbeat as log collector and it fitted perfectly to my needs