### PR TITLE
[Proposal] Ability to customize maintenance page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VER
  && tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
  && rm /docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
 
-COPY network_internal.conf /etc/nginx/
+COPY network_internal.conf maintenance_internal.conf /etc/nginx/
 
 COPY . /app/
 WORKDIR /app/

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -21,7 +21,7 @@ RUN wget --quiet https://github.com/jwilder/docker-gen/releases/download/$DOCKER
  && tar -C /usr/local/bin -xvzf docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
  && rm /docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
 
-COPY network_internal.conf /etc/nginx/
+COPY network_internal.conf maintenance_internal.conf /etc/nginx/
 
 COPY . /app/
 WORKDIR /app/

--- a/maintenance_internal.conf
+++ b/maintenance_internal.conf
@@ -1,0 +1,8 @@
+error_page 503 @maintenance;
+recursive_error_pages on;
+location @maintenance {
+    error_page 405 = /index.html;
+    add_header Cache-Control no-cache;
+    root /usr/share/nginx/html/maintenance;
+    rewrite ^(.*)$ /index.html break;
+}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -148,6 +148,9 @@ server {
 	listen [::]:{{ $external_http_port }};
 	{{ end }}
 	{{ $access_log }}
+	{{ if (exists "/usr/share/nginx/html/maintenance/index.html") }}
+	include /etc/nginx/maintenance_internal.conf;
+	{{ end }}
 	return 503;
 }
 
@@ -159,6 +162,9 @@ server {
 	listen [::]:{{ $external_https_port }} ssl http2;
 	{{ end }}
 	{{ $access_log }}
+	{{ if (exists "/usr/share/nginx/html/maintenance/index.html") }}
+	include /etc/nginx/maintenance_internal.conf;
+	{{ end }}
 	return 503;
 
 	ssl_session_cache shared:SSL:50m;


### PR DESCRIPTION
Nobody wants their service to be down, but when it happens, we want to make it in a more "happier" 🌈 way

Let's say instead of rendering
![Screen Shot 2020-11-13 at 7 03 31 PM](https://user-images.githubusercontent.com/1429229/99099320-ef25ca80-25e2-11eb-9099-9165a655e3f5.png)

We could render some human readable page, like
![Screen Shot 2020-11-13 at 7 02 40 PM](https://user-images.githubusercontent.com/1429229/99099367-02389a80-25e3-11eb-8ebc-22d440274770.png)

**P.S.** _This is just a proposal.
I did a quick test and it works.

Would be great to here any feedback if it's relevant_


