### PR TITLE
Added support to set a different https redirect port and set proxy timeout time

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ site after changing this setting, your browser has probably cached the HSTS poli
 redirecting you back to HTTPS.  You will need to clear your browser's HSTS cache or use an incognito
 window / different browser.
 
+### HTTPS External redirect port
+
+By default when `HTTPS_METHOD=redirect`. nginx will redirect connections on port HTPP 80 to default HTTPS 443 port, with `HTTPS_REDIRECT_PORT=port` you can change this behavior to another port, for example `HTTPS_REDIRECT_PORT=8443`
+
+### HSTS
+
 By default, [HTTP Strict Transport Security (HSTS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) 
 is enabled with `max-age=31536000` for HTTPS sites.  You can disable HSTS with the environment variable 
 `HSTS=off` or use a custom HSTS configuration like `HSTS=max-age=31536000; includeSubDomains; preload`.  

--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ backend container. Your backend container should then listen on a port rather
 than a socket and expose that port.
 
 ### FastCGI Backends
- 
+
 If you would like to connect to FastCGI backend, set `VIRTUAL_PROTO=fastcgi` on the
 backend container. Your backend container should then listen on a port rather
 than a socket and expose that port.
- 
+
 ### FastCGI File Root Directory
 
 If you use fastcgi,you can set `VIRTUAL_ROOT=xxx`  for your root directory
@@ -143,6 +143,12 @@ If you use fastcgi,you can set `VIRTUAL_ROOT=xxx`  for your root directory
 To set the default host for nginx use the env var `DEFAULT_HOST=foo.bar.com` for example
 
     $ docker run -d -p 80:80 -e DEFAULT_HOST=foo.bar.com -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+
+### Default https redirect port
+
+When `HTTPS_METHOD=redirect` defined in container, the default https redirect port will be 443 for all conteiners, set the env var `DEFAULT_HTTPS_REDIRECT_PORT=443` in nginx container to change this behavior, for example:
+
+    $ docker run -d -p 80:80 -e DEFAULT_HTTPS_REDIRECT_PORT=8443 -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
 
 
 ### Separate Containers
@@ -292,17 +298,17 @@ site after changing this setting, your browser has probably cached the HSTS poli
 redirecting you back to HTTPS.  You will need to clear your browser's HSTS cache or use an incognito
 window / different browser.
 
-### HTTPS External redirect port
+### HTTPS External redirect port per container config
 
-By default when `HTTPS_METHOD=redirect`. nginx will redirect connections on port HTPP 80 to default HTTPS 443 port, with `HTTPS_REDIRECT_PORT=port` you can change this behavior to another port, for example `HTTPS_REDIRECT_PORT=8443`
+By default when `HTTPS_METHOD=redirect` nginx will redirect connections on port HTPP 80 to 443 port or value defined in `DEFAULT_HTTPS_REDIRECT_PORT`, with `HTTPS_REDIRECT_PORT=port` you can change this behavior to another port, for example `HTTPS_REDIRECT_PORT=8443`
 
 ### HSTS
 
-By default, [HTTP Strict Transport Security (HSTS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) 
-is enabled with `max-age=31536000` for HTTPS sites.  You can disable HSTS with the environment variable 
-`HSTS=off` or use a custom HSTS configuration like `HSTS=max-age=31536000; includeSubDomains; preload`.  
-*WARNING*: HSTS will force your users to visit the HTTPS version of your site for the `max-age` time - 
-even if they type in `http://` manually.  The only way to get to an HTTP site after receiving an HSTS 
+By default, [HTTP Strict Transport Security (HSTS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
+is enabled with `max-age=31536000` for HTTPS sites.  You can disable HSTS with the environment variable
+`HSTS=off` or use a custom HSTS configuration like `HSTS=max-age=31536000; includeSubDomains; preload`.
+*WARNING*: HSTS will force your users to visit the HTTPS version of your site for the `max-age` time -
+even if they type in `http://` manually.  The only way to get to an HTTP site after receiving an HSTS
 response is to clear your browser's HSTS cache.
 
 ### Basic Authentication Support

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ When `HTTPS_METHOD=redirect` defined in container, the default https redirect po
 
     $ docker run -d -p 80:80 -e DEFAULT_HTTPS_REDIRECT_PORT=8443 -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
 
+### Default proxy timeout
+
+The default proxy timeout time will be 60s for all conteiners, set the env var `DEFAULT_PROXY_TIMEOUT=2m` in nginx container to change this behavior, for example:
+
+    $ docker run -d -p 80:80 -e DEFAULT_PROXY_TIMEOUT=300s -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+
 
 ### Separate Containers
 
@@ -300,7 +306,12 @@ window / different browser.
 
 ### HTTPS External redirect port per container config
 
-By default when `HTTPS_METHOD=redirect` nginx will redirect connections on port HTPP 80 to 443 port or value defined in `DEFAULT_HTTPS_REDIRECT_PORT`, with `HTTPS_REDIRECT_PORT=port` you can change this behavior to another port, for example `HTTPS_REDIRECT_PORT=8443`
+By default when `HTTPS_METHOD=redirect` nginx will redirect connections on port HTPP 80 to 443 port or value defined in `DEFAULT_HTTPS_REDIRECT_PORT`, with `HTTPS_REDIRECT_PORT=port` you can change this behavior by container to another port, for example `HTTPS_REDIRECT_PORT=8443`
+
+### PROXY Timeout
+
+By default nginx will drop a connection after 60s or value defined in `DEFAULT_PROXY_TIMEOUT`, with `PROXY_TIMEOUT=time` you can change this behavior by container to another time, for example `PROXY_TIMEOUT=180s`
+
 
 ### HSTS
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -216,6 +216,9 @@ upstream {{ $upstream_name }} {
 {{/* Get the HTTPS_METHOD defined by containers w/ the same vhost, falling back to "redirect" */}}
 {{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) (or $.Env.HTTPS_METHOD "redirect") }}
 
+{{/* Get the HTTPS_REDIRECT_PORT defined by containers w/ the same vhost, falling back to "443" */}}
+{{ $https_redirect_port := or (first (groupByKeys $containers "Env.HTTPS_REDIRECT_PORT")) (or $.Env.HTTPS_REDIRECT_PORT "443") }}
+
 {{/* Get the SSL_POLICY defined by containers w/ the same vhost, falling back to empty string (use default) */}}
 {{ $ssl_policy := or (first (groupByKeys $containers "Env.SSL_POLICY")) "" }}
 
@@ -262,7 +265,7 @@ server {
 	}
 	
 	location / {
-		return 301 https://$host$request_uri;
+		return 301 https://$host:{{ $https_redirect_port }}$request_uri;
 	}
 }
 {{ end }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -207,6 +207,7 @@ upstream {{ $upstream_name }} {
 {{ $default_host := or ($.Env.DEFAULT_HOST) "" }}
 {{ $default_server := index (dict $host "" $default_host "default_server") $host }}
 {{ $default_https_redirect_port := or ($.Env.DEFAULT_HTTPS_REDIRECT_PORT) "443" }}
+{{ $default_proxy_timeout := or ($.Env.DEFAULT_PROXY_TIMEOUT) "60s" }}
 
 {{/* Get the VIRTUAL_PROTO defined by containers w/ the same vhost, falling back to "http" */}}
 {{ $proto := trim (or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http") }}
@@ -219,6 +220,9 @@ upstream {{ $upstream_name }} {
 
 {{/* Get the HTTPS_REDIRECT_PORT defined by containers w/ the same vhost, falling back to "443" */}}
 {{ $https_redirect_port := or (first (groupByKeys $containers "Env.HTTPS_REDIRECT_PORT")) (or $.Env.HTTPS_REDIRECT_PORT $default_https_redirect_port) }}
+
+{{/* Get the PROXY_TIMEOUT defined by containers w/ the same vhost, falling back to "60s" */}}
+{{ $proxy_timeout := or (first (groupByKeys $containers "Env.PROXY_TIMEOUT")) (or $.Env.PROXY_TIMEOUT $default_proxy_timeout)) }}
 
 {{/* Get the SSL_POLICY defined by containers w/ the same vhost, falling back to empty string (use default) */}}
 {{ $ssl_policy := or (first (groupByKeys $containers "Env.SSL_POLICY")) "" }}
@@ -255,7 +259,7 @@ server {
 	listen [::]:{{ $external_http_port }} {{ $default_server }};
 	{{ end }}
 	{{ $access_log }}
-	
+
 	# Do not HTTPS redirect Let'sEncrypt ACME challenge
 	location /.well-known/acme-challenge/ {
 		auth_basic off;
@@ -264,7 +268,7 @@ server {
 		try_files $uri =404;
 		break;
 	}
-	
+
 	location / {
 		return 301 https://$host:{{ $https_redirect_port }}$request_uri;
 	}
@@ -289,6 +293,11 @@ server {
 	ssl_session_timeout 5m;
 	ssl_session_cache shared:SSL:50m;
 	ssl_session_tickets off;
+
+	send_timeout {{ $proxy_timeout }};
+	proxy_connect_timeout {{ $proxy_timeout }};
+	proxy_send_timeout {{ $proxy_timeout }};
+	proxy_read_timeout {{ $proxy_timeout }};
 
 	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
 	ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -222,7 +222,7 @@ upstream {{ $upstream_name }} {
 {{ $https_redirect_port := or (first (groupByKeys $containers "Env.HTTPS_REDIRECT_PORT")) (or $.Env.HTTPS_REDIRECT_PORT $default_https_redirect_port) }}
 
 {{/* Get the PROXY_TIMEOUT defined by containers w/ the same vhost, falling back to "60s" */}}
-{{ $proxy_timeout := or (first (groupByKeys $containers "Env.PROXY_TIMEOUT")) (or $.Env.PROXY_TIMEOUT $default_proxy_timeout)) }}
+{{ $proxy_timeout := or (first (groupByKeys $containers "Env.PROXY_TIMEOUT")) (or $.Env.PROXY_TIMEOUT $default_proxy_timeout) }}
 
 {{/* Get the SSL_POLICY defined by containers w/ the same vhost, falling back to empty string (use default) */}}
 {{ $ssl_policy := or (first (groupByKeys $containers "Env.SSL_POLICY")) "" }}
@@ -294,10 +294,10 @@ server {
 	ssl_session_cache shared:SSL:50m;
 	ssl_session_tickets off;
 
-	send_timeout {{ $proxy_timeout }};
-	proxy_connect_timeout {{ $proxy_timeout }};
-	proxy_send_timeout {{ $proxy_timeout }};
-	proxy_read_timeout {{ $proxy_timeout }};
+	send_timeout {{ trim $proxy_timeout }};
+	proxy_connect_timeout {{ trim $proxy_timeout }};
+	proxy_send_timeout {{ trim $proxy_timeout }};
+	proxy_read_timeout {{ trim $proxy_timeout }};
 
 	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
 	ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -206,6 +206,7 @@ upstream {{ $upstream_name }} {
 
 {{ $default_host := or ($.Env.DEFAULT_HOST) "" }}
 {{ $default_server := index (dict $host "" $default_host "default_server") $host }}
+{{ $default_https_redirect_port := or ($.Env.DEFAULT_HTTPS_REDIRECT_PORT) "443" }}
 
 {{/* Get the VIRTUAL_PROTO defined by containers w/ the same vhost, falling back to "http" */}}
 {{ $proto := trim (or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http") }}
@@ -217,7 +218,7 @@ upstream {{ $upstream_name }} {
 {{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) (or $.Env.HTTPS_METHOD "redirect") }}
 
 {{/* Get the HTTPS_REDIRECT_PORT defined by containers w/ the same vhost, falling back to "443" */}}
-{{ $https_redirect_port := or (first (groupByKeys $containers "Env.HTTPS_REDIRECT_PORT")) (or $.Env.HTTPS_REDIRECT_PORT "443") }}
+{{ $https_redirect_port := or (first (groupByKeys $containers "Env.HTTPS_REDIRECT_PORT")) (or $.Env.HTTPS_REDIRECT_PORT $default_https_redirect_port) }}
 
 {{/* Get the SSL_POLICY defined by containers w/ the same vhost, falling back to empty string (use default) */}}
 {{ $ssl_policy := or (first (groupByKeys $containers "Env.SSL_POLICY")) "" }}


### PR DESCRIPTION
In my enviroment, i cant use the public https 443, so i changed your code to allow custom external redirect ports global or per container defined.

Image on docker hub abelmferreira/nginx-proxy:alpine