### PR TITLE
Add support for virtual host redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ services:
   whoami:
     image: jwilder/whoami
     environment:
-      - VIRTUAL_HOST=whoami.local
+      - VIRTUAL_HOST=whoami.local,www.whoami.local
+      - REDIRECT=www.whoami.local
 ```
 
 ```shell
@@ -81,6 +82,10 @@ If you need to support multiple virtual hosts for a container, you can separate 
 ### Wildcard Hosts
 
 You can also use wildcards at the beginning and the end of host name, like `*.bar.com` or `foo.bar.*`. Or even a regular expression, which can be very useful in conjunction with a wildcard DNS service like [xip.io](http://xip.io), using `~^foo\.bar\..*\.xip\.io` will match `foo.bar.127.0.0.1.xip.io`, `foo.bar.10.0.2.2.xip.io` and all other given IPs. More information about this topic can be found in the nginx documentation about [`server_names`](http://nginx.org/en/docs/http/server_names.html).
+
+### Redirect Hosts
+
+Using the `REDIRECT` environment variable, you can 301 permanent redirect all your virtual hosts to a specific host. Commonly used in production for SEO purposes. For example, you can redirect both `www.bar.com,bar.com` to `www.bar.com` using `REDIRECT=www.bar.com` or `www.bar.com,bar.com` to `bar.com` using `REDIRECT=bar.com`.
 
 ### Multiple Networks
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -225,6 +225,8 @@ upstream {{ $upstream_name }} {
 {{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
 {{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
 
+{{/* Get the first redirect defined by containers w/ the same vhost */}}
+{{ $redirectHost := or (first (groupByKeys $containers "Env.REDIRECT")) ""}}
 
 {{/* Get the first cert name defined by containers w/ the same vhost */}}
 {{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}
@@ -260,10 +262,20 @@ server {
 		try_files $uri =404;
 		break;
 	}
-	
+
+	{{ if (and $redirectHost (ne $redirectHost $host)) }}
+        # Redirect host {{ $host }} => {{ $redirectHost }}
+        {{ end }}
+
+	{{ if (and $redirectHost (ne $redirectHost $host)) }}
+	location / {
+                return 301 https://{{ $redirectHost }}$request_uri;
+        }
+	{{ else }}
 	location / {
 		return 301 https://$host$request_uri;
 	}
+	{{ end }}
 }
 {{ end }}
 
@@ -308,7 +320,12 @@ server {
 	{{ else if (exists "/etc/nginx/vhost.d/default") }}
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
+	
+	{{ if (and $redirectHost (ne $redirectHost $host)) }}
+        # Redirect host {{ $host }} => {{ $redirectHost }}
+        {{ end }}
 
+	{{ if (or (not $redirectHost) (eq $redirectHost $host)) }}
 	location / {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
@@ -333,6 +350,13 @@ server {
 		include /etc/nginx/vhost.d/default_location;
 		{{ end }}
 	}
+	{{ end }}
+
+	{{ if (and $redirectHost (ne $redirectHost $host)) }}
+        location / {
+                return 301 https://{{$redirectHost}}$request_uri;
+        }
+        {{ end }}
 }
 
 {{ end }}
@@ -357,7 +381,12 @@ server {
 	{{ else if (exists "/etc/nginx/vhost.d/default") }}
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
+	
+	{{ if (and $redirectHost (ne $redirectHost $host)) }}
+        # Redirect host {{ $host }} => {{ $redirectHost }}
+        {{ end }}
 
+	{{ if (or (not $redirectHost) (eq $redirectHost $host)) }}
 	location / {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
@@ -381,6 +410,13 @@ server {
 		include /etc/nginx/vhost.d/default_location;
 		{{ end }}
 	}
+	{{ end }}
+
+	{{ if (and $redirectHost (ne $redirectHost $host)) }}
+	location / {
+                return 301 http://{{ $redirectHost }}$request_uri;
+        }
+	{{ end }}	
 }
 
 {{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}


### PR DESCRIPTION
Added the `REDIRECT` environment variable to solve issues #180, #960, #958, #444, #1095 and an alternative to #1369.
Should work for both HTTP and HTTPS, depending on what is configured and perform a single redirect.

The config below does `non-www` to `www`,
```yaml
environment:
    - VIRTUAL_HOST: test.com,www.test.com,a.test.com
    - REDIRECT: www.test.com
    - LETSENCRYPT_HOST: test.com,www.test.com,a.test.com
```
will create the 301 redirects below

```
test.com -> www.test.com
a.test.com -> www.test.com
```

The config below does `www` to `non-www`,
```yaml
environment:
    - VIRTUAL_HOST: test.com,www.test.com,a.test.com
    - REDIRECT: test.com
    - LETSENCRYPT_HOST: test.com,www.test.com,a.test.com
```
will create the 301 redirects below

```
www.test.com -> test.com
a.test.com -> test.com
```


