### PR TITLE
Python 2 to 3

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -471,5 +471,5 @@ try:
 except docker.errors.ImageNotFound:
     pytest.exit("The docker image 'nginxproxy/nginx-proxy:test' is missing")
 
-if docker.__version__ != "2.1.0":
-    pytest.exit("This test suite is meant to work with the python docker module v2.1.0")
+if docker.__version__ != "4.4.4":
+    pytest.exit("This test suite is meant to work with the python docker module v4.4.4")

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 # disable the creation of the `.cache` folders
 addopts = -p no:cacheprovider --ignore=requirements --ignore=certs -r s -v
+markers =
+    incremental: mark a test as incremental.

--- a/test/requirements/Dockerfile-nginx-proxy-tester
+++ b/test/requirements/Dockerfile-nginx-proxy-tester
@@ -1,4 +1,4 @@
-FROM python:2.7-alpine
+FROM python:3.9-alpine
 
 # Note: we're using alpine because it has openssl 1.0.2, which we need for testing
 RUN apk add --update bash openssl curl && rm -rf /var/cache/apk/*

--- a/test/requirements/python-requirements.txt
+++ b/test/requirements/python-requirements.txt
@@ -1,5 +1,5 @@
-backoff==1.3.2
-docker-compose==1.11.2
-docker==2.1.0
-pytest==3.0.5
-requests==2.11.1
+backoff==1.10.0
+docker-compose==1.28.5
+docker==4.4.4
+pytest==6.2.2
+requests==2.25.1

--- a/test/requirements/web/webserver.py
+++ b/test/requirements/web/webserver.py
@@ -13,13 +13,13 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         if self.path == "/headers":
             response_body += self.headers.as_string()
         elif self.path == "/port":
-            response_body += "answer from port %s\n" % PORT
+            response_body += f"answer from port {PORT}\n"
         elif re.match("/status/(\d+)", self.path):
             result = re.match("/status/(\d+)", self.path)
             response_code = int(result.group(1))
-            response_body += "answer with response code %s\n" % response_code
+            response_body += f"answer with response code {response_code}\n"
         elif self.path == "/":
-            response_body += "I'm %s\n" % os.environ['HOSTNAME']
+            response_body += f"I'm {os.environ['HOSTNAME']}\n"
         else:
             response_body += "No route for this path!\n"
             response_code = 404

--- a/test/stress_tests/test_deleted_cert/test_restart_while_missing_cert.py
+++ b/test/stress_tests/test_deleted_cert/test_restart_while_missing_cert.py
@@ -12,7 +12,7 @@ script_dir = os.path.dirname(__file__)
 pytestmark = pytest.mark.xfail()  # TODO delete this marker once those issues are fixed
 
 
-@pytest.yield_fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def certs():
     """
     pytest fixture that provides cert and key files into the tmp_certs directory
@@ -43,7 +43,7 @@ def test_http_web_is_301(docker_compose, nginxproxy):
 def test_https_web_is_200(docker_compose, nginxproxy):
     r = nginxproxy.get("https://web.nginx-proxy/port")
     assert r.status_code == 200
-    assert 'answer from port 81\n' in r.text
+    assert "answer from port 81\n" in r.text
 
 
 @pytest.mark.incremental

--- a/test/test_custom/test_location-per-vhost.py
+++ b/test/test_custom/test_location-per-vhost.py
@@ -19,4 +19,4 @@ def test_custom_conf_does_not_apply_to_web2(docker_compose, nginxproxy):
     assert "X-test" not in r.headers
 
 def test_custom_block_is_present_in_nginx_generated_conf(docker_compose, nginxproxy):
-    assert "include /etc/nginx/vhost.d/web1.nginx-proxy.local_location;" in nginxproxy.get_conf()
+    assert b"include /etc/nginx/vhost.d/web1.nginx-proxy.local_location;" in nginxproxy.get_conf()

--- a/test/test_default-host.yml
+++ b/test/test_default-host.yml
@@ -10,7 +10,7 @@ web1:
 
 # WHEN nginx-proxy runs with DEFAULT_HOST set to web1.tld
 sut:
-  image: jwilder/nginx-proxy:test
+  image: nginxproxy/nginx-proxy:test
   volumes:
     - /var/run/docker.sock:/tmp/docker.sock:ro
     - ./lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro

--- a/test/test_dockergen/test_dockergen_v2.py
+++ b/test/test_dockergen/test_dockergen_v2.py
@@ -39,4 +39,4 @@ def test_forwards_to_whoami(nginx_tmpl, docker_compose, nginxproxy):
     r = nginxproxy.get("http://whoami.nginx.container.docker/")
     assert r.status_code == 200
     whoami_container = docker_compose.containers.get("whoami")
-    assert r.text == "I'm %s\n" % whoami_container.id[:12]
+    assert r.text == f"I'm {whoami_container.id[:12]}\n"

--- a/test/test_dockergen/test_dockergen_v2.py
+++ b/test/test_dockergen/test_dockergen_v2.py
@@ -4,7 +4,7 @@ import logging
 import pytest
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture(scope="module")
 def nginx_tmpl():
     """
     pytest fixture which extracts the the nginx config template from
@@ -13,14 +13,18 @@ def nginx_tmpl():
     script_dir = os.path.dirname(__file__)
     logging.info("extracting nginx.tmpl from nginxproxy/nginx-proxy:test")
     docker_client = docker.from_env()
-    print(docker_client.containers.run(
-        image='nginxproxy/nginx-proxy:test',
-        remove=True,
-        volumes=['{current_dir}:{current_dir}'.format(current_dir=script_dir)],
-        entrypoint='sh',
-        command='-xc "cp /app/nginx.tmpl {current_dir} && chmod 777 {current_dir}/nginx.tmpl"'.format(
-            current_dir=script_dir),
-        stderr=True))
+    print(
+        docker_client.containers.run(
+            image='nginxproxy/nginx-proxy:test',
+            remove=True,
+            volumes=["{current_dir}:{current_dir}".format(current_dir=script_dir)],
+            entrypoint="sh",
+            command='-xc "cp /app/nginx.tmpl {current_dir} && chmod 777 {current_dir}/nginx.tmpl"'.format(
+                current_dir=script_dir
+            ),
+            stderr=True,
+        )
+    )
     yield
     logging.info("removing nginx.tmpl")
     os.remove(os.path.join(script_dir, "nginx.tmpl"))

--- a/test/test_dockergen/test_dockergen_v3.py
+++ b/test/test_dockergen/test_dockergen_v3.py
@@ -24,8 +24,7 @@ def versiontuple(v):
 raw_version = docker.from_env().version()["Version"]
 pytestmark = pytest.mark.skipif(
     versiontuple(raw_version) < (1, 13),
-    reason="Docker compose syntax v3 requires docker engine v1.13 or later (got %s)"
-    % raw_version,
+    reason="Docker compose syntax v3 requires docker engine v1.13 or later (got {raw_version})"
 )
 
 
@@ -64,7 +63,7 @@ def test_forwards_to_whoami(nginx_tmpl, docker_compose, nginxproxy):
     r = nginxproxy.get("http://whoami.nginx.container.docker/")
     assert r.status_code == 200
     whoami_container = docker_compose.containers.get("whoami")
-    assert r.text == "I'm %s\n" % whoami_container.id[:12]
+    assert r.text == f"I'm {whoami_container.id[:12]}\n"
 
 
 if __name__ == "__main__":

--- a/test/test_dockergen/test_dockergen_v3.py
+++ b/test/test_dockergen/test_dockergen_v3.py
@@ -18,16 +18,18 @@ def versiontuple(v):
     >>> versiontuple("17.03.0-ce") < (1, 13)
     False
     """
-    return tuple(map(int, (v.split('-')[0].split("."))))
+    return tuple(map(int, (v.split("-")[0].split("."))))
 
 
-raw_version = docker.from_env().version()['Version']
+raw_version = docker.from_env().version()["Version"]
 pytestmark = pytest.mark.skipif(
     versiontuple(raw_version) < (1, 13),
-    reason="Docker compose syntax v3 requires docker engine v1.13 or later (got %s)" % raw_version)
+    reason="Docker compose syntax v3 requires docker engine v1.13 or later (got %s)"
+    % raw_version,
+)
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture(scope="module")
 def nginx_tmpl():
     """
     pytest fixture which extracts the the nginx config template from
@@ -36,14 +38,18 @@ def nginx_tmpl():
     script_dir = os.path.dirname(__file__)
     logging.info("extracting nginx.tmpl from nginxproxy/nginx-proxy:test")
     docker_client = docker.from_env()
-    print(docker_client.containers.run(
-        image='nginxproxy/nginx-proxy:test',
-        remove=True,
-        volumes=['{current_dir}:{current_dir}'.format(current_dir=script_dir)],
-        entrypoint='sh',
-        command='-xc "cp /app/nginx.tmpl {current_dir} && chmod 777 {current_dir}/nginx.tmpl"'.format(
-            current_dir=script_dir),
-        stderr=True))
+    print(
+        docker_client.containers.run(
+            image='nginxproxy/nginx-proxy:test',
+            remove=True,
+            volumes=["{current_dir}:{current_dir}".format(current_dir=script_dir)],
+            entrypoint="sh",
+            command='-xc "cp /app/nginx.tmpl {current_dir} && chmod 777 {current_dir}/nginx.tmpl"'.format(
+                current_dir=script_dir
+            ),
+            stderr=True,
+        )
+    )
     yield
     logging.info("removing nginx.tmpl")
     os.remove(os.path.join(script_dir, "nginx.tmpl"))
@@ -61,6 +67,6 @@ def test_forwards_to_whoami(nginx_tmpl, docker_compose, nginxproxy):
     assert r.text == "I'm %s\n" % whoami_container.id[:12]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
     doctest.testmod()

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -7,7 +7,7 @@ import pytest
 from docker.errors import NotFound
 
 
-@pytest.yield_fixture()
+@pytest.fixture()
 def web1(docker_compose):
     """
     pytest fixture creating a web container with `VIRTUAL_HOST=web1.nginx-proxy` listening on port 81.

--- a/test/test_ssl/test_dhparam.py
+++ b/test/test_ssl/test_dhparam.py
@@ -26,7 +26,7 @@ def assert_log_contains(expected_log_line):
     """
     sut_container = docker_client.containers.get("nginxproxy")
     docker_logs = sut_container.logs(stdout=True, stderr=True, stream=False, follow=False)
-    assert expected_log_line in docker_logs
+    assert bytes(expected_log_line, encoding="utf8") in docker_logs
 
 
 def require_openssl(required_version):
@@ -42,7 +42,7 @@ def require_openssl(required_version):
     """
 
     def versiontuple(v):
-        clean_v = re.sub("[^\d\.]", "", v)
+        clean_v = re.sub(r"[^\d\.]", "", v)
         return tuple(map(int, (clean_v.split("."))))
 
     try:
@@ -52,7 +52,7 @@ def require_openssl(required_version):
     else:
         if not command_output:
             raise Exception("Could not get openssl version")
-        openssl_version = command_output.split()[1]
+        openssl_version = str(command_output.split()[1])
         return pytest.mark.skipif(
             versiontuple(openssl_version) < versiontuple(required_version),
             reason="openssl v%s is less than required version %s" % (openssl_version, required_version))
@@ -71,8 +71,8 @@ def test_dhparam_is_not_generated_if_present(docker_compose):
     assert_log_contains("Custom dhparam.pem file found, generation skipped")
 
     # Make sure the dhparam in use is not the default, pre-generated one
-    default_checksum = sut_container.exec_run("md5sum /app/dhparam.pem.default").split()
-    current_checksum = sut_container.exec_run("md5sum /etc/nginx/dhparam/dhparam.pem").split()
+    default_checksum = sut_container.exec_run("md5sum /app/dhparam.pem.default").output.split()
+    current_checksum = sut_container.exec_run("md5sum /etc/nginx/dhparam/dhparam.pem").output.split()
     assert default_checksum[0] != current_checksum[0]
 
 
@@ -89,5 +89,5 @@ def test_web5_dhparam_is_used(docker_compose):
 
     host = "%s:443" % sut_container.attrs["NetworkSettings"]["IPAddress"]
     r = subprocess.check_output(
-        "echo '' | openssl s_client -connect %s -cipher 'EDH' | grep 'Server Temp Key'" % host, shell=True)
-    assert "Server Temp Key: X25519, 253 bits\n" == r
+        f"echo '' | openssl s_client -connect {host} -cipher 'EDH' | grep 'Server Temp Key'", shell=True)
+    assert b"Server Temp Key: X25519, 253 bits\n" == r

--- a/test/test_ssl/test_dhparam.py
+++ b/test/test_ssl/test_dhparam.py
@@ -55,7 +55,7 @@ def require_openssl(required_version):
         openssl_version = str(command_output.split()[1])
         return pytest.mark.skipif(
             versiontuple(openssl_version) < versiontuple(required_version),
-            reason="openssl v%s is less than required version %s" % (openssl_version, required_version))
+            reason=f"openssl v{openssl_version} is less than required version {required_version}")
 
 
 ###############################################################################
@@ -87,7 +87,7 @@ def test_web5_dhparam_is_used(docker_compose):
     sut_container = docker_client.containers.get("nginxproxy")
     assert sut_container.status == "running"
 
-    host = "%s:443" % sut_container.attrs["NetworkSettings"]["IPAddress"]
+    host = f"{sut_container.attrs['NetworkSettings']['IPAddress']}:443"
     r = subprocess.check_output(
         f"echo '' | openssl s_client -connect {host} -cipher 'EDH' | grep 'Server Temp Key'", shell=True)
     assert b"Server Temp Key: X25519, 253 bits\n" == r

--- a/test/test_ssl/test_dhparam_generation.py
+++ b/test/test_ssl/test_dhparam_generation.py
@@ -22,7 +22,7 @@ def assert_log_contains(expected_log_line):
     """
     sut_container = docker_client.containers.get("nginxproxy")
     docker_logs = sut_container.logs(stdout=True, stderr=True, stream=False, follow=False)
-    assert expected_log_line in docker_logs
+    assert bytes(expected_log_line, encoding="utf8") in docker_logs
 
 
 ###############################################################################

--- a/test/test_ssl/test_dhparam_generation.py
+++ b/test/test_ssl/test_dhparam_generation.py
@@ -35,10 +35,10 @@ def test_dhparam_is_generated_if_missing(docker_compose):
     sut_container = docker_client.containers.get("nginxproxy")
     assert sut_container.status == "running"
 
-    assert_log_contains("Generating DH parameters")
+    assert_log_contains("Generating DSA parameters")
     assert_log_contains("dhparam generation complete, reloading nginx")
 
     # Make sure the dhparam in use is not the default, pre-generated one
-    default_checksum = sut_container.exec_run("md5sum /app/dhparam.pem.default").split()
-    generated_checksum = sut_container.exec_run("md5sum /etc/nginx/dhparam/dhparam.pem").split()
+    default_checksum = sut_container.exec_run("md5sum /app/dhparam.pem.default").output.split()
+    generated_checksum = sut_container.exec_run("md5sum /etc/nginx/dhparam/dhparam.pem").output.split()
     assert default_checksum[0] != generated_checksum[0]

--- a/test/test_ssl/test_wildcard.py
+++ b/test/test_ssl/test_wildcard.py
@@ -3,21 +3,21 @@ import pytest
 
 @pytest.mark.parametrize("subdomain", ["foo", "bar"])
 def test_web1_http_redirects_to_https(docker_compose, nginxproxy, subdomain):
-    r = nginxproxy.get("http://%s.nginx-proxy.tld/" % subdomain, allow_redirects=False)
+    r = nginxproxy.get(f"http://{subdomain}.nginx-proxy.tld/", allow_redirects=False)
     assert r.status_code == 301
     assert "Location" in r.headers
-    assert "https://%s.nginx-proxy.tld/" % subdomain == r.headers['Location']
+    assert f"https://{subdomain}.nginx-proxy.tld/" == r.headers['Location']
 
 
 @pytest.mark.parametrize("subdomain", ["foo", "bar"])
 def test_web1_https_is_forwarded(docker_compose, nginxproxy, subdomain):
-    r = nginxproxy.get("https://%s.nginx-proxy.tld/port" % subdomain, allow_redirects=False)
+    r = nginxproxy.get(f"https://{subdomain}.nginx-proxy.tld/port", allow_redirects=False)
     assert r.status_code == 200
     assert "answer from port 81\n" in r.text
 
 
 @pytest.mark.parametrize("subdomain", ["foo", "bar"])
 def test_web1_HSTS_policy_is_active(docker_compose, nginxproxy, subdomain):
-    r = nginxproxy.get("https://%s.nginx-proxy.tld/port" % subdomain, allow_redirects=False)
+    r = nginxproxy.get(f"https://{subdomain}.nginx-proxy.tld/port", allow_redirects=False)
     assert "answer from port 81\n" in r.text
     assert "Strict-Transport-Security" in r.headers

--- a/test/test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py
+++ b/test/test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py
@@ -9,19 +9,19 @@ from requests.exceptions import SSLError
     (3, False),
 ])
 def test_http_redirects_to_https(docker_compose, nginxproxy, subdomain, should_redirect_to_https):
-    r = nginxproxy.get("http://%s.web.nginx-proxy.tld/port" % subdomain)
+    r = nginxproxy.get(f"http://{subdomain}.web.nginx-proxy.tld/port")
     if should_redirect_to_https:
         assert len(r.history) > 0
         assert r.history[0].is_redirect
-        assert r.history[0].headers.get("Location") == "https://%s.web.nginx-proxy.tld/port" % subdomain
-    assert "answer from port 8%s\n" % subdomain == r.text
+        assert r.history[0].headers.get("Location") == f"https://{subdomain}.web.nginx-proxy.tld/port"
+    assert f"answer from port 8{subdomain}\n" == r.text
 
 
 @pytest.mark.parametrize("subdomain", [1, 2])
 def test_https_get_served(docker_compose, nginxproxy, subdomain):
-    r = nginxproxy.get("https://%s.web.nginx-proxy.tld/port" % subdomain, allow_redirects=False)
+    r = nginxproxy.get(f"https://{subdomain}.web.nginx-proxy.tld/port", allow_redirects=False)
     assert r.status_code == 200
-    assert "answer from port 8%s\n" % subdomain == r.text
+    assert f"answer from port 8{subdomain}\n" == r.text
 
 
 def test_web3_https_is_500_and_SSL_validation_fails(docker_compose, nginxproxy):

--- a/test/test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py
+++ b/test/test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py
@@ -1,5 +1,5 @@
 import pytest
-from backports.ssl_match_hostname import CertificateError
+from ssl import CertificateError
 from requests.exceptions import SSLError
 
 

--- a/test/test_wildcard_host.py
+++ b/test/test_wildcard_host.py
@@ -18,9 +18,9 @@ import pytest
     ("web4.whatever.nginx-proxy.regexp", 84),
 ])
 def test_wildcard_prefix(docker_compose, nginxproxy, host, expected_port):
-    r = nginxproxy.get("http://%s/port" % host)
+    r = nginxproxy.get(f"http://{host}/port")
     assert r.status_code == 200
-    assert r.text == "answer from port %s\n" % expected_port
+    assert r.text == f"answer from port {expected_port}\n"
 
 
 @pytest.mark.parametrize("host", [
@@ -28,5 +28,5 @@ def test_wildcard_prefix(docker_compose, nginxproxy, host, expected_port):
     "web4.whatever.nginx-proxy.regexp-to-infinity-and-beyond"
 ])
 def test_non_matching_host_is_503(docker_compose, nginxproxy, host):
-    r = nginxproxy.get("http://%s/port" % host)
+    r = nginxproxy.get(f"http://{host}/port")
     assert r.status_code == 503, r.text


### PR DESCRIPTION
Porting Python 2 Code used on tests to Python 3 and updated dependencies.


Tests Results:
```bash
❯ pipenv run pytest
============================================================================================================= test session starts =======================================================
platform linux -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/kmarilleau/.local/share/virtualenvs/test-X-i_1pMX/bin/python
rootdir: /home/kmarilleau/work/nginx-proxy/nginx-proxy/test, configfile: pytest.ini
collected 129 items

test_DOCKER_HOST_unix_socket.py::test_unknown_virtual_host PASSED                                                                                                                  [  0%]
[...]
test_ipv6.py::test_unknown_virtual_host_ipv6 SKIPPED (Container test_sut_1 has no IPv6 address)                                                                                    [  9%]
test_ipv6.py::test_forwards_to_web1_ipv6 SKIPPED (Container test_sut_1 has no IPv6 address)                                                                                        [ 10%]
test_ipv6.py::test_forwards_to_web2_ipv6 SKIPPED (Container test_sut_1 has no IPv6 address)                                                                                        [ 10%]
[...]
test_nominal.py::test_ipv6_is_disabled_by_default SKIPPED (Container test_sut_1 has no IPv6 address)                                                                               [ 18%]
[...]
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_unknown_virtual_host_is_503 XPASS                                                                          [ 31%]
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_http_web_is_301 XPASS                                                                                      [ 32%]
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_https_web_is_200 XPASS                                                                                     [ 33%]
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_delete_cert_and_restart_reverseproxy XFAIL                                                                 [ 34%]
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_unknown_virtual_host_is_still_503 XFAIL (previous test failed (test_delete_cert_and_restart_reverseproxy)) [ 34%]
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_http_web_is_now_200 XFAIL (previous test failed (test_unknown_virtual_host_is_still_503))                  [ 35%]
stress_tests/test_deleted_cert/test_restart_while_missing_cert.py::test_https_web_is_now_broken_since_there_is_no_cert XFAIL (previous test failed (test_http_web_is_now_200))     [ 36%]
stress_tests/test_unreachable_network/test_unreachable_net.py::test_default_nginx_welcome_page_should_not_be_served XPASS                                                          [ 37%]
stress_tests/test_unreachable_network/test_unreachable_net.py::test_unknown_virtual_host_is_503 XPASS                                                                              [ 37%]
stress_tests/test_unreachable_network/test_unreachable_net.py::test_http_web_a_is_forwarded XPASS                                                                                  [ 38%]
stress_tests/test_unreachable_network/test_unreachable_net.py::test_http_web_b_gets_an_error XPASS                                                                                 [ 39%]
stress_tests/test_unreachable_network/test_unreachable_net.py::test_reverseproxy_survive_restart XPASS                                                                             [ 40%]
[...]
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_web3_https_is_500_and_SSL_validation_fails PASSED                                                           [100%]

============================================================================================================== warnings summary =========================================================
test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_web3_https_is_500_and_SSL_validation_fails
  /home/kmarilleau/.local/share/virtualenvs/test-X-i_1pMX/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to  
host '3.web.nginx-proxy.tld'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=========================================================================================================== short test summary info =====================================================
SKIPPED [4] conftest.py:135: Container test_sut_1 has no IPv6 address
================================================================================= 113 passed, 4 skipped, 4 xfailed, 8 xpassed, 1 warning in 217.32s (0:03:37) ===========================
```
