### PR TITLE
Prevent incorrect loading of wildcard domains in vhost configuration.

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -353,7 +353,7 @@ server {
 	{{ end }}
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
-	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+	include {{ printf "/etc/nginx/vhost.d/%s" (replace $host "*" "\\*" -1) }};
 	{{ else if (exists "/etc/nginx/vhost.d/default") }}
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
@@ -376,7 +376,7 @@ server {
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
-		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+		include {{ printf "/etc/nginx/vhost.d/%s_location" (replace $host "*" "\\*" -1) }};
 		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
 		include /etc/nginx/vhost.d/default_location;
 		{{ end }}


### PR DESCRIPTION
I can specify the virtual host in the following format.

```
myhome.mydomain.com
*.mydomain.com
```

In this case, it will be saved in vhost.d as follows.

```
myhome.mydomain.com_location
*.mydomain.com_location
```

However, in this case, the nginx template recognizes * as a wildcard of the file system and loads all saved files ending in '.mydomain.com_location'. This is clearly wrong.