### PR TITLE
Added ssl client support when req'd files present

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -294,6 +294,26 @@ server {
 	ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
 	{{ end }}
 
+	{{/* SSL Client Certificate Validation */}}
+	{{/* If we have a client specific ca (form of fqdn.ca.crt) then use that */}}
+	{{ if (exists (printf "/etc/nginx/certs/%s.ca.crt" $cert)) }}
+	ssl_client_certificate {{ printf "/etc/nginx/certs/%s.ca.crt" $cert }};
+	ssl_verify_client on;
+	{{/* If a corresponding crl is present for the fqdn specific ca include it */}}
+	{{ if (exists (printf "/etc/nginx/certs/%s.ca.crl" $cert)) }}
+	ssl_crl {{ printf "/etc/nginx/certs/%s.ca.crl" $cert }};
+	{{ end }}
+	{{/* If we didn't have a client specific ca (ca.crt) but we have a global one use that */}}
+	{{ else if (exists "/etc/nginx/certs/ca.crt") }}
+	ssl_client_certificate /etc/nginx/certs/ca.crt;
+	ssl_verify_client on;
+	{{/* If a corresponding crl is present for the global ca include it */}}
+	{{ if (exists "/etc/nginx/certs/ca.crl")}}
+	ssl_crl /etc/nginx/certs/ca.crl;
+	{{ end }}
+	{{ end }}
+
+
 	{{ if (exists (printf "/etc/nginx/certs/%s.chain.pem" $cert)) }}
 	ssl_stapling on;
 	ssl_stapling_verify on;


### PR DESCRIPTION
This pull request resolves nginx-proxy/nginx-proxy#278 by modifying the nginx.tmpl to add support for either per host or global certificates and certificate revocation lists for client certificate verification.

To use a user must ensure that either a certificate authority is uploaded into /etc/nginx/certs when they start their proxied containers. To apply a ca globally the file must be called ca.crt and the crl must be ca.crl. To limit client certificate verification to a specific FQDN then the CA and optional CRL must be uploaded to /etc/nginx/certs with their name in the format of fqdn.ca.crt and fqdn.ca.crl (IE test.example.com.ca).