### PR TITLE
Update docker-gen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # setup build arguments for version of dependencies to use
-ARG DOCKER_GEN_VERSION=0.7.4
+ARG DOCKER_GEN_VERSION=0.7.5
 ARG FOREGO_VERSION=0.16.1
 
 # Use a specific version of golang to build both binaries


### PR DESCRIPTION
It was updated https://github.com/jwilder/docker-gen/releases/tag/0.7.5

I'm getting `no servers are inside upstream in /etc/nginx/conf.d/default.conf:58` I think it should have been fixed by https://github.com/jwilder/docker-gen/pull/336