### PR TITLE
Bump docker-gen from 0.7.4 to 0.7.6

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # setup build arguments for version of dependencies to use
-ARG DOCKER_GEN_VERSION=0.7.4
+ARG DOCKER_GEN_VERSION=0.7.6
 ARG FOREGO_VERSION=0.16.1
 
 # Use a specific version of golang to build both binaries
@@ -9,22 +9,19 @@ RUN apk add --no-cache git
 # Build docker-gen from scratch
 FROM gobuilder as dockergen
 
-# Download the sources for the given version
 ARG DOCKER_GEN_VERSION
-ADD https://github.com/jwilder/docker-gen/archive/${DOCKER_GEN_VERSION}.tar.gz sources.tar.gz
 
-# Move the sources into the right directory
-RUN tar -xzf sources.tar.gz && \
-   mkdir -p /go/src/github.com/jwilder/ && \
-   mv docker-gen-* /go/src/github.com/jwilder/docker-gen
-
-# Install the dependencies and make the docker-gen executable
-WORKDIR /go/src/github.com/jwilder/docker-gen
-RUN go get -v ./... && \
-   CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.buildVersion=${DOCKER_GEN_VERSION}" ./cmd/docker-gen
+RUN git clone https://github.com/jwilder/docker-gen \
+   && cd /go/docker-gen \
+   && git -c advice.detachedHead=false checkout $DOCKER_GEN_VERSION \
+   && go mod download \
+   && CGO_ENABLED=0 go build -ldflags "-X main.buildVersion=${DOCKER_GEN_VERSION}" ./cmd/docker-gen \
+   && go clean -cache \
+   && mv docker-gen /usr/local/bin/ \
+   && cd - \
+   && rm -rf /go/docker-gen
 
 # Build forego from scratch
-# Because this relies on golang workspaces, we need to use go < 1.8. 
 FROM gobuilder as forego
 
 # Download the sources for the given version
@@ -43,7 +40,7 @@ RUN go get -v ./... && \
 
 # Build the final image
 FROM nginx:1.19.3-alpine
-LABEL maintainer="Jason Wilder mail@jasonwilder.com"
+LABEL maintainer="Nicolas Duchon <nicolas.duchon@gmail.com> (@buchdag)"
 
 # Install wget and install/updates certificates
 RUN apk add --no-cache --virtual .run-deps \
@@ -57,7 +54,7 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
 
 # Install Forego + docker-gen
 COPY --from=forego /go/src/github.com/ddollar/forego/forego /usr/local/bin/forego
-COPY --from=dockergen /go/src/github.com/jwilder/docker-gen/docker-gen /usr/local/bin/docker-gen
+COPY --from=dockergen /usr/local/bin/docker-gen /usr/local/bin/docker-gen
 
 # Add DOCKER_GEN_VERSION environment variable
 # Because some external projects rely on it


### PR DESCRIPTION
This PR updates **jwilder/docker-gen** to the latest tagged release, `0.7.6`, which should fixe a number of `no servers inside upstream in /etc/nginx/conf.d/default.conf` issues.

The Dockerfiles are now fetching docker-gen sources using `git` rather than downloading a tar archive. The fetching of the sources, building and cleanup are done in a single layer to minimize the size of the intermediate-stage image.

close #1548
close #1585
close #1586
close #1600