### PR TITLE
Chore: switch to go mod compatible fork of forego

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # setup build arguments for version of dependencies to use
 ARG DOCKER_GEN_VERSION=0.7.6
-ARG FOREGO_VERSION=0.16.1
+ARG FOREGO_VERSION=v0.17.0
 
 # Use a specific version of golang to build both binaries
 FROM golang:1.15.10 as gobuilder
@@ -21,22 +21,19 @@ RUN git clone https://github.com/jwilder/docker-gen \
    && rm -rf /go/docker-gen
 
 # Build forego from scratch
-# Because this relies on golang workspaces, we need to use go < 1.8. 
 FROM gobuilder as forego
 
-# Download the sources for the given version
 ARG FOREGO_VERSION
-ADD https://github.com/jwilder/forego/archive/v${FOREGO_VERSION}.tar.gz sources.tar.gz
 
-# Move the sources into the right directory
-RUN tar -xzf sources.tar.gz && \
-   mkdir -p /go/src/github.com/ddollar/ && \
-   mv forego-* /go/src/github.com/ddollar/forego
-
-# Install the dependencies and make the forego executable
-WORKDIR /go/src/github.com/ddollar/forego/
-RUN go get -v ./... && \
-   CGO_ENABLED=0 GOOS=linux go build -o forego .
+RUN git clone https://github.com/nginx-proxy/forego/ \
+   && cd /go/forego \
+   && git -c advice.detachedHead=false checkout $FOREGO_VERSION \
+   && go mod download \
+   && CGO_ENABLED=0 GOOS=linux go build -o forego . \
+   && go clean -cache \
+   && mv forego /usr/local/bin/ \
+   && cd - \
+   && rm -rf /go/forego
 
 # Build the final image
 FROM nginx:1.19.3
@@ -56,7 +53,7 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf
 
 # Install Forego + docker-gen
-COPY --from=forego /go/src/github.com/ddollar/forego/forego /usr/local/bin/forego
+COPY --from=forego /usr/local/bin/forego /usr/local/bin/forego
 COPY --from=dockergen /usr/local/bin/docker-gen /usr/local/bin/docker-gen
 
 # Add DOCKER_GEN_VERSION environment variable

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,6 @@
 # setup build arguments for version of dependencies to use
 ARG DOCKER_GEN_VERSION=0.7.6
-ARG FOREGO_VERSION=0.16.1
+ARG FOREGO_VERSION=v0.17.0
 
 # Use a specific version of golang to build both binaries
 FROM golang:1.15.10-alpine as gobuilder
@@ -24,19 +24,17 @@ RUN git clone https://github.com/jwilder/docker-gen \
 # Build forego from scratch
 FROM gobuilder as forego
 
-# Download the sources for the given version
 ARG FOREGO_VERSION
-ADD https://github.com/jwilder/forego/archive/v${FOREGO_VERSION}.tar.gz sources.tar.gz
 
-# Move the sources into the right directory
-RUN tar -xzf sources.tar.gz && \
-   mkdir -p /go/src/github.com/ddollar/ && \
-   mv forego-* /go/src/github.com/ddollar/forego
-
-# Install the dependencies and make the forego executable
-WORKDIR /go/src/github.com/ddollar/forego/
-RUN go get -v ./... && \
-   CGO_ENABLED=0 GOOS=linux go build -o forego .
+RUN git clone https://github.com/nginx-proxy/forego/ \
+   && cd /go/forego \
+   && git -c advice.detachedHead=false checkout $FOREGO_VERSION \
+   && go mod download \
+   && CGO_ENABLED=0 GOOS=linux go build -o forego . \
+   && go clean -cache \
+   && mv forego /usr/local/bin/ \
+   && cd - \
+   && rm -rf /go/forego
 
 # Build the final image
 FROM nginx:1.19.3-alpine
@@ -47,13 +45,12 @@ RUN apk add --no-cache --virtual .run-deps \
     ca-certificates bash wget openssl \
     && update-ca-certificates
 
-
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf
 
 # Install Forego + docker-gen
-COPY --from=forego /go/src/github.com/ddollar/forego/forego /usr/local/bin/forego
+COPY --from=forego /usr/local/bin/forego /usr/local/bin/forego
 COPY --from=dockergen /usr/local/bin/docker-gen /usr/local/bin/docker-gen
 
 # Add DOCKER_GEN_VERSION environment variable


### PR DESCRIPTION
As discussed in #1579, **forego** isn't maintained anymore and lacks go module support. This project was already using a fork of forego by jwilder, so I decided to fork it again under the nginx-proxy org and merge in go mod support (thanks to @tkw1536) so that can it be used in this project and unblock building the image with golang >= `1.16`.