### PR TITLE
Fix broken create_server_certificate.sh

### DIFF
--- a/test/certs/create_server_certificate.sh
+++ b/test/certs/create_server_certificate.sh
@@ -24,7 +24,7 @@ fi
 # Create a nginx container (which conveniently provides the `openssl` command)
 ###############################################################################
 
-CONTAINER=$(docker run -d -v $DIR:/work -w /work -e SAN="$ALTERNATE_DOMAINS" nginx:1.14.1)
+CONTAINER=$(docker run -d -v $DIR:/work -w /work -e SAN="$ALTERNATE_DOMAINS" nginx:1.19.10)
 # Configure openssl
 docker exec $CONTAINER bash -c '
 	mkdir -p /ca/{certs,crl,private,newcerts} 2>/dev/null


### PR DESCRIPTION
Docker image `nginx:1.14.1` has no `openssl` installed. Therefore upgrading to `nginx:1.19.10`.

**Before**:
```
$ test/certs/create_server_certificate.sh web.nginx-proxy.tld
Unable to find image 'nginx:1.14.1' locally
1.14.1: Pulling from library/nginx
a5a6f2f73cd8: Pulling fs layer
2343eb083a4e: Pulling fs layer
251439d5b33c: Pulling fs layer
251439d5b33c: Verifying Checksum
251439d5b33c: Download complete
a5a6f2f73cd8: Verifying Checksum
a5a6f2f73cd8: Download complete
2343eb083a4e: Verifying Checksum
2343eb083a4e: Download complete
a5a6f2f73cd8: Pull complete
2343eb083a4e: Pull complete
251439d5b33c: Pull complete
Digest: sha256:32fdf92b4e986e109e4db0865758020cb0c3b70d6ba80d02fe87bad5cc3dc228
Status: Downloaded newer image for nginx:1.14.1

> Create a host key: /home/lauris/git/nginx-proxy/test/certs/web.nginx-proxy.tld.key
OCI runtime exec failed: exec failed: container_linux.go:367: starting container process caused: exec: "openssl": executable file not found in $PATH: unknown

> Create a host certificate signing request
OCI runtime exec failed: exec failed: container_linux.go:367: starting container process caused: exec: "openssl": executable file not found in $PATH: unknown

ERROR: failed to generate server certificate signing request
5277f33ba1df12112c6e3b3dda985f01f0e6a1c267fda22424df2f21071fa070
```

**After**:
```
$ test/certs/create_server_certificate.sh web.nginx-proxy.tld
Unable to find image 'nginx:1.19.10' locally
1.19.10: Pulling from library/nginx
Digest: sha256:75a55d33ecc73c2a242450a9f1cc858499d468f077ea942867e662c247b5e412
Status: Downloaded newer image for nginx:1.19.10

> Create a host key: /home/lauris/git/nginx-proxy/test/certs/web.nginx-proxy.tld.key
Generating RSA private key, 2048 bit long modulus (2 primes)
..................+++++
...............+++++
e is 65537 (0x010001)

> Create a host certificate signing request
Ignoring -days; not generating a certificate

> Create server certificate: /home/lauris/git/nginx-proxy/test/certs/web.nginx-proxy.tld.crt
Using configuration from /ca/openssl.cnf
Check that the request matches the signature
Signature ok
Certificate Details:
        Serial Number: 4096 (0x1000)
        Validity
            Not Before: May 11 09:33:10 2021 GMT
            Not After : Sep 26 09:33:10 2048 GMT
        Subject:
            commonName                = web.nginx-proxy.tld
        X509v3 extensions:
            X509v3 Subject Alternative Name: 
                DNS:web.nginx-proxy.tld
Certificate is to be certified until Sep 26 09:33:10 2048 GMT (10000 days)

Write out database with 1 new entries
Data Base Updated
```