### PR TITLE
Docs and tests for custom HTTP/HTTPS ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ In this example, the `my-nginx-proxy` container will be connected to `my-network
 
 ### Custom external HTTP/HTTPS ports
 
-If you want to use `nginx-proxy` with different external ports that the default ones of `80` for `HTTP` traffic and `443` for `HTTPS` traffic, you'll have to use the environment variable(s) `HTTP_PORT` and/or `HTTPS_PORT` in addition to the changes to the Docker port mapping. Typical usage, here with the custom ports `1080` and `10443`:
+If you want to use `nginx-proxy` with different external ports that the default ones of `80` for `HTTP` traffic and `443` for `HTTPS` traffic, you'll have to use the environment variable(s) `HTTP_PORT` and/or `HTTPS_PORT` in addition to the changes to the Docker port mapping. If you change the `HTTPS` port, the redirect for `HTTPS` traffic will also be configured to redirect to the custom port. Typical usage, here with the custom ports `1080` and `10443`:
 
     $ docker run -d -p 1080:1080 -p 10443:10443 -e HTTP_PORT=1080 -e HTTPS_PORT=10443 -v /var/run/docker.sock:/tmp/docker.sock:ro nginxproxy/nginx-proxy
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ $ docker network connect my-other-network my-nginx-proxy
 
 In this example, the `my-nginx-proxy` container will be connected to `my-network` and `my-other-network` and will be able to proxy to other containers attached to those networks.
 
+### Custom external HTTP/HTTPS ports
+
+If you want to use `nginx-proxy` with different external ports that the default ones of `80` for `HTTP` traffic and `443` for `HTTPS` traffic, you'll have to use the environment variable(s) `HTTP_PORT` and/or `HTTPS_PORT` in addition to the changes to the Docker port mapping. Typical usage, here with the custom ports `1080` and `10443`:
+
+    $ docker run -d -p 1080:1080 -p 10443:10443 -e HTTP_PORT=1080 -e HTTPS_PORT=10443 -v /var/run/docker.sock:/tmp/docker.sock:ro nginxproxy/nginx-proxy
+
 ### Internet vs. Local Network Access
 
 If you allow traffic from the public internet to access your `nginx-proxy` container, you may want to restrict some containers to the internal network only, so they cannot be accessed from the public internet.  On containers that should be restricted to the internal network, you should set the environment variable `NETWORK_ACCESS=internal`.  By default, the *internal* network is defined as `127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16`.  To change the list of networks considered internal, mount a file on the `nginx-proxy` at `/etc/nginx/network_internal.conf` with these contents, edited to suit your needs:

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -276,7 +276,11 @@ server {
 	}
 	
 	location / {
+		{{ if eq $external_https_port "443" }}
 		return 301 https://$host$request_uri;
+		{{ else }}
+		return 301 https://$host:{{ $external_https_port }}$request_uri;
+		{{ end }}
 	}
 }
 {{ end }}

--- a/test/test_http_port.py
+++ b/test/test_http_port.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.mark.parametrize("subdomain", ["foo", "bar"])
+def test_web1_http_custom_port(docker_compose, nginxproxy, subdomain):
+    r = nginxproxy.get("http://%s.nginx-proxy.tld:8080/port" % subdomain, allow_redirects=False)
+    assert r.status_code == 200
+    assert "answer from port 81\n" in r.text

--- a/test/test_http_port.yml
+++ b/test/test_http_port.yml
@@ -1,0 +1,15 @@
+web1:
+  image: web
+  expose:
+    - "81"
+  environment:
+    WEB_PORTS: "81"
+    VIRTUAL_HOST: "*.nginx-proxy.tld"
+
+sut:
+  image: nginxproxy/nginx-proxy:test
+  volumes:
+    - /var/run/docker.sock:/tmp/docker.sock:ro
+    - ./lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro
+  environment:
+    HTTP_PORT: 8080

--- a/test/test_ssl/test_https_port.py
+++ b/test/test_ssl/test_https_port.py
@@ -1,0 +1,14 @@
+import pytest
+
+@pytest.mark.parametrize("subdomain", ["foo", "bar"])
+def test_web1_http_redirects_to_https(docker_compose, nginxproxy, subdomain):
+    r = nginxproxy.get("http://%s.nginx-proxy.tld:8080/" % subdomain, allow_redirects=False)
+    assert r.status_code == 301
+    assert "Location" in r.headers
+    assert "https://%s.nginx-proxy.tld:8443/" % subdomain == r.headers['Location']
+
+@pytest.mark.parametrize("subdomain", ["foo", "bar"])
+def test_web1_https_is_forwarded(docker_compose, nginxproxy, subdomain):
+    r = nginxproxy.get("https://%s.nginx-proxy.tld:8443/port" % subdomain, allow_redirects=False)
+    assert r.status_code == 200
+    assert "answer from port 81\n" in r.text

--- a/test/test_ssl/test_https_port.yml
+++ b/test/test_ssl/test_https_port.yml
@@ -1,0 +1,17 @@
+web1:
+  image: web
+  expose:
+    - "81"
+  environment:
+    WEB_PORTS: "81"
+    VIRTUAL_HOST: "*.nginx-proxy.tld"
+
+sut:
+  image: nginxproxy/nginx-proxy:test
+  volumes:
+    - /var/run/docker.sock:/tmp/docker.sock:ro
+    - ../lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro
+    - ./certs:/etc/nginx/certs:ro
+  environment:
+    HTTP_PORT: 8080
+    HTTPS_PORT: 8443


### PR DESCRIPTION
This PR adds docs and tests for #1353  plus fix and tests for HTTPS redirection when using custom HTTPS port.

The fix and the tests are adapted from those of @stuckj in #1234