### PR TITLE
Use `server 127.0.0.1 down` entry only when required

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -4,28 +4,6 @@
 {{ $external_https_port := coalesce $.Env.HTTPS_PORT "443" }}
 {{ $debug_all := $.Env.DEBUG }}
 
-{{ define "upstream" }}
-	{{ if .Address }}
-		{{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
-		{{ if and .Container.Node.ID .Address.HostPort }}
-	# {{ .Container.Node.Name }}/{{ .Container.Name }}
-			server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }};
-		{{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
-		{{ else if .Network }}
-	# {{ .Container.Name }}
-	server {{ .Network.IP }}:{{ .Address.Port }};
-		{{ end }}
-	{{ else if .Network }}
-	# {{ .Container.Name }}
-		{{ if .Network.IP }}
-	server {{ .Network.IP }}:{{ .VirtualPort }};
-		{{ else }}
-	# /!\ No IP for this network!
-		{{ end }}
-	{{ end }}
-
-{{ end }}
-
 {{ define "ssl_policy" }}
 	{{ if eq .ssl_policy "Mozilla-Modern" }}
 		ssl_protocols TLSv1.3;
@@ -184,29 +162,52 @@ upstream {{ $upstream_name }} {
 	{{ $debug := (eq (coalesce $container.Env.DEBUG $debug_all "false") "true") }}
 	{{/* If only 1 port exposed, use that as a default, else 80 */}}
 	{{ $defaultPort := (when (eq (len $container.Addresses) 1) (first $container.Addresses) (dict "Port" "80")).Port }}
+	{{ $port := (coalesce $container.Env.VIRTUAL_PORT $defaultPort) }}
+	{{ $address := where $container.Addresses "Port" $port | first }}
+	{{ if $debug }}
+	# Exposed ports: {{ $container.Addresses }}
+	# Default virtual port: {{ $defaultPort }}
+	# VIRTUAL_PORT: {{ $container.Env.VIRTUAL_PORT }}
+		{{ if not $address }}
+	# /!\ Virtual port not exposed
+		{{ end }}
+	{{ end }}
+	{{ $server_found := "false" }}
 	{{ range $knownNetwork := $CurrentContainer.Networks }}
 		{{ range $containerNetwork := $container.Networks }}
 			{{ if (and (ne $containerNetwork.Name "ingress") (or (eq $knownNetwork.Name $containerNetwork.Name) (eq $knownNetwork.Name "host"))) }}
 	## Can be connected with "{{ $containerNetwork.Name }}" network
-				{{ $port := (coalesce $container.Env.VIRTUAL_PORT $defaultPort) }}
-				{{ $address := where $container.Addresses "Port" $port | first }}
-				{{ if $debug }}
-	# Exposed ports: {{ $container.Addresses }}
-	# Default virtual port: {{ $defaultPort }}
-	# VIRTUAL_PORT: {{ $container.Env.VIRTUAL_PORT }}
-					{{ if not $address }}
-	# /!\ Virtual port not exposed
+				{{ if $address }}
+					{{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
+					{{ if and $container.Node.ID $address.HostPort }}
+						{{ $server_found = "true" }}
+	# {{ $container.Node.Name }}/{{ $container.Name }}
+	server {{ $container.Node.Address.IP }}:{{ $address.HostPort }};
+					{{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
+					{{ else if $containerNetwork }}
+						{{ $server_found = "true" }}
+	# {{ $container.Name }}
+	server {{ $containerNetwork.IP }}:{{ $address.Port }};
+					{{ end }}
+				{{ else if $containerNetwork }}
+	# {{ $container.Name }}
+					{{ if $containerNetwork.IP }}
+						{{ $server_found = "true" }}
+	server {{ $containerNetwork.IP }}:{{ $port }};
+					{{ else }}
+	# /!\ No IP for this network!
 					{{ end }}
 				{{ end }}
-				{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork "VirtualPort" $port) }}
 			{{ else }}
 	# Cannot connect to network '{{ $containerNetwork.Name }}' of this container
 			{{ end }}
 		{{ end }}
 	{{ end }}
 	{{/* nginx-proxy/nginx-proxy#1105 */}}
+	{{ if (eq $server_found "false") }}
 	# Fallback entry
 	server 127.0.0.1 down;
+	{{ end }}
 {{ end }}
 }
 

--- a/test/test_debug/test_proxy-debug-flag.py
+++ b/test/test_debug/test_proxy-debug-flag.py
@@ -9,4 +9,4 @@ def test_debug_info_is_present_in_nginx_generated_conf(docker_compose, nginxprox
            re.search(r"# Exposed ports: \[\{\d+\.\d+\.\d+\.\d+\s+83\s+tcp \} \{\d+\.\d+\.\d+\.\d+\s+82\s+tcp \}\]", conf)
     assert "# Default virtual port: 80" in conf
     assert "# VIRTUAL_PORT: 82" in conf
-    assert conf.count("# /!\ Virtual port not exposed") == 1
+    assert conf.count("# /!\\ Virtual port not exposed") == 1

--- a/test/test_server-down/test_no-server-down.py
+++ b/test/test_server-down/test_no-server-down.py
@@ -1,0 +1,8 @@
+import pytest
+
+def test_web_has_no_server_down(docker_compose, nginxproxy):
+    conf = nginxproxy.get_conf().decode('ASCII')
+    r = nginxproxy.get("http://web.nginx-proxy.tld/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 81\n"
+    assert conf.count("server 127.0.0.1 down;") == 0

--- a/test/test_server-down/test_no-server-down.yml
+++ b/test/test_server-down/test_no-server-down.yml
@@ -1,0 +1,13 @@
+web:
+  image: web
+  expose:
+    - "81"
+  environment:
+    WEB_PORTS: 81
+    VIRTUAL_HOST: web.nginx-proxy.tld
+
+sut:
+  image: nginxproxy/nginx-proxy:test
+  volumes:
+    - /var/run/docker.sock:/tmp/docker.sock:ro
+    - ../lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro

--- a/test/test_server-down/test_server-down.py
+++ b/test/test_server-down/test_server-down.py
@@ -1,0 +1,7 @@
+import pytest
+
+def test_web_has_server_down(docker_compose, nginxproxy):
+    conf = nginxproxy.get_conf().decode('ASCII')
+    r = nginxproxy.get("http://web.nginx-proxy.tld/port")
+    assert r.status_code in [502, 503]
+    assert conf.count("server 127.0.0.1 down;") == 1

--- a/test/test_server-down/test_server-down.yml
+++ b/test/test_server-down/test_server-down.yml
@@ -1,0 +1,14 @@
+web:
+  image: web
+  expose:
+    - "81"
+  environment:
+    WEB_PORTS: 81
+    VIRTUAL_HOST: web.nginx-proxy.tld
+  net: "none"
+
+sut:
+  image: nginxproxy/nginx-proxy:test
+  volumes:
+    - /var/run/docker.sock:/tmp/docker.sock:ro
+    - ../lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro


### PR DESCRIPTION
See https://github.com/nginx-proxy/nginx-proxy/pull/1609#issuecomment-858150285.

Additionally, fix a warning due to a missing backslash escaping from previous merge request.