### PR TITLE
Bump docker-gen from 0.7.6 to 0.7.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,17 +41,17 @@ LABEL maintainer="Nicolas Duchon <nicolas.duchon@gmail.com> (@buchdag)"
 
 # Install wget and install/updates certificates
 RUN apt-get update \
- && apt-get install -y -q --no-install-recommends \
-    ca-certificates \
-    wget \
- && apt-get clean \
- && rm -r /var/lib/apt/lists/*
+   && apt-get install -y -q --no-install-recommends \
+   ca-certificates \
+   wget \
+   && apt-get clean \
+   && rm -r /var/lib/apt/lists/*
 
 
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
- && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
- && sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf
+   && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
+   && sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf
 
 # Install Forego + docker-gen
 COPY --from=forego /usr/local/bin/forego /usr/local/bin/forego

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # setup build arguments for version of dependencies to use
-ARG DOCKER_GEN_VERSION=0.7.6
+ARG DOCKER_GEN_VERSION=0.7.7
 ARG FOREGO_VERSION=v0.17.0
 
 # Use a specific version of golang to build both binaries

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # setup build arguments for version of dependencies to use
-ARG DOCKER_GEN_VERSION=0.7.6
+ARG DOCKER_GEN_VERSION=0.7.7
 ARG FOREGO_VERSION=v0.17.0
 
 # Use a specific version of golang to build both binaries

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -42,13 +42,13 @@ LABEL maintainer="Nicolas Duchon <nicolas.duchon@gmail.com> (@buchdag)"
 
 # Install wget and install/updates certificates
 RUN apk add --no-cache --virtual .run-deps \
-    ca-certificates bash wget openssl \
-    && update-ca-certificates
+   ca-certificates bash wget openssl \
+   && update-ca-certificates
 
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
- && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
- && sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf
+   && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
+   && sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf
 
 # Install Forego + docker-gen
 COPY --from=forego /usr/local/bin/forego /usr/local/bin/forego


### PR DESCRIPTION
This PR updates **docker-gen** to release `0.7.7`.

This might fix some lingering issues where docker-gen can't find its own container ID in some OSes and Docker versions, which in turn leads to configurations where all `upstream` contains only `server 127.0.0.1 down;` (see https://github.com/nginx-proxy/docker-gen/issues/355)