### PR TITLE
Use sha1 of hostname as upstream names

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -153,8 +153,7 @@ server {
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
 
 {{ $host := trim $host }}
-{{ $is_regexp := hasPrefix "~" $host }}
-{{ $upstream_name := (print (when $is_regexp (sha1 $host) $host) "-upstream") }}
+{{ $upstream_name := sha1 $host }}
 
 # {{ $host }}
 upstream {{ $upstream_name }} {

--- a/test/test_raw-ip-vhost.py
+++ b/test/test_raw-ip-vhost.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+def test_raw_ipv4_vhost_forwards_to_web1(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://172.20.0.4")
+    assert r.status_code == 200
+    web1_container = docker_compose.containers.get("web1")
+    assert r.text == f"I'm {web1_container.id[:12]}\n"
+
+
+def test_raw_ipv6_vhost_forwards_to_web2(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://[fd00::4]", ipv6=True)
+    assert r.status_code == 200
+    web2_container = docker_compose.containers.get("web2")
+    assert r.text == f"I'm {web2_container.id[:12]}\n"

--- a/test/test_raw-ip-vhost.yml
+++ b/test/test_raw-ip-vhost.yml
@@ -1,0 +1,48 @@
+version: '2'
+
+networks:
+  net1:
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16
+        - subnet: fd00::/80  
+
+services:
+  web1:
+    container_name: web1
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: "172.20.0.4"
+    networks:
+      net1:
+        ipv4_address: 172.20.0.2
+        ipv6_address: fd00::2
+
+  web2:
+    container_name: web2
+    image: web
+    expose:
+      - "82"
+    environment:
+      WEB_PORTS: 82
+      VIRTUAL_HOST: "[fd00::4]"
+    networks:
+      net1:
+        ipv4_address: 172.20.0.3
+        ipv6_address: fd00::3
+
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    environment:
+      ENABLE_IPV6: "true"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro
+    networks:
+      net1:
+        ipv4_address: 172.20.0.4
+        ipv6_address: fd00::4


### PR DESCRIPTION
This PR adds tests for raw IPv4/IPv6 `VIRTUAL_HOST` and fixes #1693 by using sha1 hashes of the hostname as `upstream` names (which was already the case for regexp `VIRTUAL_HOST`) rather than suffixing the hostname with `-upstream`.