### PR TITLE
tests: Fix pytest container networking issues

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -362,6 +362,10 @@ def connect_to_network(network):
         # figure out our container networks
         my_networks = list(my_container.attrs["NetworkSettings"]["Networks"].keys())
 
+        # If the pytest container is using host networking, it cannot connect to container networks (not required with host network) 
+        if 'host' in my_networks:
+            return None
+
         # make sure our container is connected to the nginx-proxy's network
         if network not in my_networks:
             logging.info(f"Connecting to docker network: {network.name}")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,7 +28,9 @@ FORCE_CONTAINER_IPV6 = False  # ugly global state to consider containers' IPv6 a
 
 
 docker_client = docker.from_env()
-test_container = socket.gethostname()
+
+# Name of pytest container to reference if it's being used for running tests
+test_container = 'nginx-proxy-pytest'
 
 
 ###############################################################################
@@ -260,7 +262,7 @@ def restore_urllib_dns_resolver(getaddrinfo_func):
 
 def remove_all_containers():
     for container in docker_client.containers.list(all=True):
-        if PYTEST_RUNNING_IN_CONTAINER and container.id.startswith(test_container):
+        if PYTEST_RUNNING_IN_CONTAINER and container.name == test_container:
             continue  # pytest is running within a Docker container, so we do not want to remove that particular container
         logging.info(f"removing container {container.name}")
         container.remove(v=True, force=True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -34,9 +34,9 @@ test_container = 'nginx-proxy-pytest'
 
 
 ###############################################################################
-# 
+#
 # utilities
-# 
+#
 ###############################################################################
 
 @contextlib.contextmanager
@@ -60,7 +60,7 @@ def ipv6(force_ipv6=True):
 
 class requests_for_docker(object):
     """
-    Proxy for calling methods of the requests module. 
+    Proxy for calling methods of the requests module.
     When a HTTP response failed due to HTTP Error 404 or 502, retry a few times.
     Provides method `get_conf` to extract the nginx-proxy configuration content.
     """
@@ -224,7 +224,7 @@ def docker_container_dns_resolver(domain_name):
 
     ip = container_ip(container)
     log.info(f"resolving domain name {domain_name!r} as IP address {ip} of container {container.name}")
-    return ip 
+    return ip
 
 
 def monkey_patch_urllib_dns_resolver():
@@ -306,7 +306,7 @@ def docker_compose_down(compose_file='docker-compose.yml'):
 
 def wait_for_nginxproxy_to_be_ready():
     """
-    If one (and only one) container started from image nginxproxy/nginx-proxy:test is found, 
+    If one (and only one) container started from image nginxproxy/nginx-proxy:test is found,
     wait for its log to contain substring "Watching docker events"
     """
     containers = docker_client.containers.list(filters={"ancestor": "nginxproxy/nginx-proxy:test"})
@@ -416,18 +416,18 @@ def connect_to_all_networks():
 
 
 ###############################################################################
-# 
+#
 # Py.test fixtures
-# 
+#
 ###############################################################################
 
 @pytest.fixture(scope="module")
 def docker_compose(request):
     """
     pytest fixture providing containers described in a docker compose file. After the tests, remove the created containers
-    
+
     A custom docker compose file name can be defined in a variable named `docker_compose_file`.
-    
+
     Also, in the case where pytest is running from a docker container, this fixture makes sure
     our container will be attached to all the docker networks.
     """
@@ -463,9 +463,9 @@ def nginxproxy():
 
 
 ###############################################################################
-# 
+#
 # Py.test hooks
-# 
+#
 ###############################################################################
 
 # pytest hook to display additionnal stuff in test report
@@ -492,9 +492,9 @@ def pytest_runtest_setup(item):
         pytest.xfail(f"previous test failed ({previousfailed.name})")
 
 ###############################################################################
-# 
+#
 # Check requirements
-# 
+#
 ###############################################################################
 
 try:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,6 +28,7 @@ FORCE_CONTAINER_IPV6 = False  # ugly global state to consider containers' IPv6 a
 
 
 docker_client = docker.from_env()
+test_container = socket.gethostname()
 
 
 ###############################################################################
@@ -259,7 +260,7 @@ def restore_urllib_dns_resolver(getaddrinfo_func):
 
 def remove_all_containers():
     for container in docker_client.containers.list(all=True):
-        if PYTEST_RUNNING_IN_CONTAINER and container.id.startswith(socket.gethostname()):
+        if PYTEST_RUNNING_IN_CONTAINER and container.id.startswith(test_container):
             continue  # pytest is running within a Docker container, so we do not want to remove that particular container
         logging.info(f"removing container {container.name}")
         container.remove(v=True, force=True)
@@ -351,9 +352,9 @@ def connect_to_network(network):
     """
     if PYTEST_RUNNING_IN_CONTAINER:
         try:
-            my_container = docker_client.containers.get(socket.gethostname())
+            my_container = docker_client.containers.get(test_container)
         except docker.errors.NotFound:
-            logging.warn(f"container {socket.gethostname()!r} not found")
+            logging.warn(f"container {test_container} not found")
             return
 
         # figure out our container networks
@@ -374,9 +375,9 @@ def disconnect_from_network(network=None):
     """
     if PYTEST_RUNNING_IN_CONTAINER and network is not None:
         try:
-            my_container = docker_client.containers.get(socket.gethostname())
+            my_container = docker_client.containers.get(test_container)
         except docker.errors.NotFound:
-            logging.warn(f"container {socket.gethostname()!r} not found")
+            logging.warn(f"container {test_container} not found")
             return
 
         # figure out our container networks

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -367,7 +367,7 @@ def connect_to_network(network):
             return None
 
         # make sure our container is connected to the nginx-proxy's network
-        if network not in my_networks:
+        if network.name not in my_networks:
             logging.info(f"Connecting to docker network: {network.name}")
             network.connect(my_container)
             return network
@@ -405,7 +405,7 @@ def connect_to_all_networks():
         return []
     else:
         # find the list of docker networks
-        networks = [network for network in docker_client.networks.list() if len(network.containers) > 0 and network.name != 'bridge']
+        networks = [network for network in docker_client.networks.list(greedy=True) if len(network.containers) > 0 and network.name != 'bridge']
         return [connect_to_network(network) for network in networks]
 
 

--- a/test/pytest.sh
+++ b/test/pytest.sh
@@ -18,8 +18,8 @@ docker build -t nginx-proxy-tester -f "${DIR}/requirements/Dockerfile-nginx-prox
 
 # run the nginx-proxy-tester container setting the correct value for the working dir in order for 
 # docker-compose to work properly when run from within that container.
-exec docker run --rm -it \
---volume /var/run/docker.sock:/var/run/docker.sock \
---volume "${DIR}:${DIR}" \
---workdir "${DIR}" \
-nginx-proxy-tester "${ARGS[@]}"
+exec docker run --rm -it --name "nginx-proxy-pytest" \
+  --volume "/var/run/docker.sock:/var/run/docker.sock" \
+  --volume "${DIR}:${DIR}" \
+  --workdir "${DIR}" \
+  nginx-proxy-tester "${ARGS[@]}"

--- a/test/requirements/Dockerfile-nginx-proxy-tester
+++ b/test/requirements/Dockerfile-nginx-proxy-tester
@@ -1,5 +1,7 @@
 FROM python:3.9
 
+ENV PYTEST_RUNNING_IN_CONTAINER=1
+
 COPY python-requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt
 


### PR DESCRIPTION
This PR contributes [fixes I described here](https://github.com/nginx-proxy/nginx-proxy/pull/1848#issuecomment-1003247877) when investigating test failures from running pytest via the supported Docker container method (my preference).

I've scoped changes out to individual commits as usual, with commit messages adding context. The final commit does a little housekeeping with white-space so it might be a cleaner diff if you disable white-space when viewing.

---

Roughly the changes are:

- Proper detection of running `pytest` via container (`pytest.sh`) by using ENV instead of the deprecated internal file check that Docker no longer supports. We only need it for running tests and control the `pytest` Dockerfile, seems the right way to approach it :+1: 
- Supporting host networking mode instead of bridged networks. This was mostly for troubleshooting, previously it failed as the early setup removes all running containers unless they match the pytest hostname with the container ID, however host network mode will use the hosts `$HOSTNAME` / `/etc/hostname`, not the containers ID, thus the `pytest` container would accidentally remove itself. We now match by setting a container name in `pytest.sh` to compare against instead.
- By default the `pytest` container should connect to other container networks (_specifically the `nginx-proxy` one, typically a bridge network with name based on the docker-compose file name_). This wasn't happening because of a missing arg to request networks with their associated containers, and once that was corrected, several other parts were found to not be working properly, such as avoiding connecting to a network that was already connected, or avoiding `none` network (_different from passing `None`_).

Behaviour of the `pytest` container is now at parity with running it locally on the host.

Fixes #1615