### PR TITLE
Add posibility to port forward services running outside docker, adding VIRTUAL_IP env

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -175,6 +175,11 @@ upstream {{ $upstream_name }} {
 	# /!\ Virtual port not exposed
 		{{ end }}
 	{{ end }}
+	{{ if (eq $container.Env.VIRTUAL_IP "127.0.0.1") }}
+	{{ $server_found = "true" }}
+	## Detected host proxy port forward
+	server {{ $container.Env.VIRTUAL_IP }}:{{ $container.Env.VIRTUAL_PORT }};
+	{{ else }}
 	{{ range $knownNetwork := $CurrentContainer.Networks }}
 		{{ range $containerNetwork := $container.Networks }}
 			{{ if (and (ne $containerNetwork.Name "ingress") (or (eq $knownNetwork.Name $containerNetwork.Name) (eq $knownNetwork.Name "host"))) }}
@@ -204,6 +209,7 @@ upstream {{ $upstream_name }} {
 	# Cannot connect to network '{{ $containerNetwork.Name }}' of this container
 			{{ end }}
 		{{ end }}
+	{{ end }}
 	{{ end }}
 {{ end }}
 {{/* nginx-proxy/nginx-proxy#1105 */}}


### PR DESCRIPTION
`nginx-proxy` needs to run on `host` network, this is to access services outside docker:
```
docker run --detach \
    --name nginx-proxy \
    --network=host \
    -v /data/nginx-proxy/conf:/etc/nginx/conf.d  \
    -v /data/nginx-proxy/vhost:/etc/nginx/vhost.d \
    -v /data/nginx-proxy/html:/usr/share/nginx/html \
    -v /data/nginx-proxy/certs:/etc/nginx/certs \
    -v /etc/localtime:/etc/localtime:ro \
    nginx
```

This will proxy to `hostservice.example.com` a service running on port 18946 on host machine outside docker. With HTTPS on.
```
docker run --detach \
    --name webhook-proxy \
    -e VIRTUAL_HOST=hostservice.example.com \
    -e VIRTUAL_PORT=18946 \
    -e VIRTUAL_IP=127.0.0.1 \
    -e LETSENCRYPT_HOST=hostservice.example.com \
    -e LETSENCRYPT_EMAIL=hostservice@example.com \
    alpine:3.15 sleep infinity
```

Code might be improved, but this is what I've got at the moment.