### PR TITLE
Add and display nginx-proxy version

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -53,12 +53,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Retrieve version
+        run: echo "GIT_DESCRIBE=$(git describe --tags)" >> $GITHUB_ENV
+
       - name: Build and push the Debian based image
         id: docker_build_debian
         uses: docker/build-push-action@v2
         with:
           context: .
           file: Dockerfile
+          build-args: NGINX_PROXY_VERSION=${{ env.GIT_DESCRIBE }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.docker_meta_debian.outputs.tags }}
@@ -101,12 +105,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Retrieve version
+        run: echo "GIT_DESCRIBE=$(git describe --tags)" >> $GITHUB_ENV
+
       - name: Build and push the Alpine based image
         id: docker_build_alpine
         uses: docker/build-push-action@v2
         with:
           context: .
           file: Dockerfile.alpine
+          build-args: NGINX_PROXY_VERSION=${{ env.GIT_DESCRIBE }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.docker_meta_alpine.outputs.tags }}

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -40,6 +40,14 @@ RUN git clone https://github.com/nginx-proxy/forego/ \
 FROM nginx:1.21.5-alpine
 LABEL maintainer="Nicolas Duchon <nicolas.duchon@gmail.com> (@buchdag)"
 
+ARG NGINX_PROXY_VERSION
+# Add DOCKER_GEN_VERSION environment variable
+# Because some external projects rely on it
+ARG DOCKER_GEN_VERSION
+ENV NGINX_PROXY_VERSION=${NGINX_PROXY_VERSION} \
+   DOCKER_GEN_VERSION=${DOCKER_GEN_VERSION} \
+   DOCKER_HOST=unix:///tmp/docker.sock
+
 # Install wget and install/updates certificates
 RUN apk add --no-cache --virtual .run-deps \
    ca-certificates bash wget openssl \
@@ -55,17 +63,10 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
 COPY --from=forego /usr/local/bin/forego /usr/local/bin/forego
 COPY --from=dockergen /usr/local/bin/docker-gen /usr/local/bin/docker-gen
 
-# Add DOCKER_GEN_VERSION environment variable
-# Because some external projects rely on it
-ARG DOCKER_GEN_VERSION
-ENV DOCKER_GEN_VERSION=${DOCKER_GEN_VERSION}
-
 COPY network_internal.conf /etc/nginx/
 
 COPY . /app/
 WORKDIR /app/
-
-ENV DOCKER_HOST unix:///tmp/docker.sock
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["forego", "start", "-r"]

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ build-webserver:
 	docker build -t web test/requirements/web
 
 build-nginx-proxy-test-debian:
-	docker build -t nginxproxy/nginx-proxy:test .
+	docker build --build-arg NGINX_PROXY_VERSION="test" -t nginxproxy/nginx-proxy:test .
 
 build-nginx-proxy-test-alpine:
-	docker build -f Dockerfile.alpine -t nginxproxy/nginx-proxy:test .
+	docker build --build-arg NGINX_PROXY_VERSION="test" -f Dockerfile.alpine -t nginxproxy/nginx-proxy:test .
 
 test-debian: build-webserver build-nginx-proxy-test-debian
 	test/pytest.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,6 +29,12 @@ function _parse_false() {
 	esac
 }
 
+function _print_version {
+    if [[ -n "${NGINX_PROXY_VERSION:-}" ]]; then
+        echo "Info: running nginx-proxy version ${NGINX_PROXY_VERSION}"
+    fi
+}
+
 function _check_unix_socket() {
 	# Warn if the DOCKER_HOST socket does not exist
 	if [[ ${DOCKER_HOST} == unix://* ]]; then
@@ -96,6 +102,8 @@ function _setup_dhparam() {
 
 # Run the init logic if the default CMD was provided
 if [[ $* == 'forego start -r' ]]; then
+	_print_version
+	
 	_check_unix_socket
 
 	_resolvers

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -1,5 +1,6 @@
 {{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
 
+{{ $nginx_proxy_version := coalesce $.Env.NGINX_PROXY_VERSION "" }}
 {{ $external_http_port := coalesce $.Env.HTTP_PORT "80" }}
 {{ $external_https_port := coalesce $.Env.HTTPS_PORT "443" }}
 {{ $debug_all := $.Env.DEBUG }}
@@ -46,6 +47,10 @@
 		ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:DHE-DSS-AES128-SHA';
 		ssl_prefer_server_ciphers on;
 	{{ end }}
+{{ end }}
+
+{{ if ne $nginx_proxy_version "" }}
+# nginx-proxy version : {{ $nginx_proxy_version }}
 {{ end }}
 
 # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the

--- a/test/test_nominal.py
+++ b/test/test_nominal.py
@@ -22,3 +22,8 @@ def test_forwards_to_web2(docker_compose, nginxproxy):
 def test_ipv6_is_disabled_by_default(docker_compose, nginxproxy):
     with pytest.raises(ConnectionError):
         nginxproxy.get("http://nginx-proxy/port", ipv6=True)
+
+
+def test_container_version_is_displayed(docker_compose, nginxproxy):
+    conf = nginxproxy.get_conf().decode('ASCII')
+    assert "# nginx-proxy version : test" in conf


### PR DESCRIPTION
This PR adds a build argument and an associated environment variable to the Dockerfile whose intent are to store nginx-proxy's version. This environment variable is in turn used to display nginx-proxy's version at startup and on the generated nginx configuration.

The current version is retrieved and injected to the image built and pushed by the CI pretty much in the same way as in nginx-proxy/docker-gen and nginx-proxy/acme-companion.