### PR TITLE
Fix path to default.conf in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,10 +423,10 @@ Please note that using regular expressions in `VIRTUAL_HOST` will always result 
 
 ### Troubleshooting
 
-In case you can't access your VIRTUAL_HOST, set `DEBUG=true` in the client container's environment and have a look at the generated nginx configuration file `/etc/nginx/conf.d/default`:
+In case you can't access your VIRTUAL_HOST, set `DEBUG=true` in the client container's environment and have a look at the generated nginx configuration file `/etc/nginx/conf.d/default.conf`:
 
 ```console
-docker exec <nginx-proxy-instance> cat /etc/nginx/conf.d/default
+docker exec <nginx-proxy-instance> cat /etc/nginx/conf.d/default.conf
 ```
 Especially at `upstream` definition blocks which should look like:
 


### PR DESCRIPTION
`/etc/nginx/conf.d/default.conf` is accidentally listed as `/etc/nginx/conf.d/default` a couple times in README.md