### PR TITLE
Add container logs in case testcontainer exited unexpectedly

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -192,6 +192,10 @@ def nginx_proxy_dns_resolver(domain_name):
         nginxproxy_containers = docker_client.containers.list(filters={"status": "running", "ancestor": "nginxproxy/nginx-proxy:test"})
         if len(nginxproxy_containers) == 0:
             log.warn(f"no container found from image nginxproxy/nginx-proxy:test while resolving {domain_name!r}")
+            exited_nginxproxy_containers = docker_client.containers.list(filters={"status": "exited", "ancestor": "nginxproxy/nginx-proxy:test"})
+            if len(exited_nginxproxy_containers) > 0:
+                exited_nginxproxy_container_logs = exited_nginxproxy_containers[0].logs()
+                log.warn(f"nginxproxy/nginx-proxy:test container might have exited unexpectedly. Container logs: " + "\n" + exited_nginxproxy_container_logs.decode())
             return
         nginxproxy_container = nginxproxy_containers[0]
         ip = container_ip(nginxproxy_container)


### PR DESCRIPTION
When running tests against the `nginxproxy/nginx-proxy:test` it can happen that someone uses an invalid configuration yaml file for spinning up containers. It then can happen that the proxy container exits immediately and the test logs don't provide any further information.

This PR adds the docker container logs output in case the  `nginxproxy/nginx-proxy:test` exited unexpectedly before tests are run. 

A sample output looks like this:

```
DEBUG    DNS:conftest.py:243 resolving domain name ('www.web2.nginx-proxy.tld', 80, <AddressFamily.AF_INET: 2>, <SocketKind.SOCK_STREAM: 1>)
DEBUG    DNS:conftest.py:190 nginx_proxy_dns_resolver('www.web2.nginx-proxy.tld')
WARNING  DNS:conftest.py:194 no container found from image nginxproxy/nginx-proxy:test while resolving 'www.web2.nginx-proxy.tld'
WARNING  DNS:conftest.py:198 nginxproxy/nginx-proxy:test container might have exited unexpectedly. Container logs: 
Info: running nginx-proxy version test
Setting up DH Parameters..
cp: cannot create regular file '/etc/nginx/dhparam/dhparam.pem/ffdhe4096.pem': Read-only file system

DEBUG    DNS:conftest.py:213 docker_container_dns_resolver('www.web2.nginx-proxy.tld')
DEBUG    DNS:conftest.py:217 'www.web2.nginx-proxy.tld' does not match
```

The additional warning helps to figure out what went wrong especially when running test on CI platforms like Github Actions.