### PR TITLE
Bump docker-gen to 0.8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # setup build arguments for version of dependencies to use
-ARG DOCKER_GEN_VERSION=main
+ARG DOCKER_GEN_VERSION=0.8.2
 ARG FOREGO_VERSION=v0.17.0
 
 # Use a specific version of golang to build both binaries

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # setup build arguments for version of dependencies to use
-ARG DOCKER_GEN_VERSION=main
+ARG DOCKER_GEN_VERSION=0.8.2
 ARG FOREGO_VERSION=v0.17.0
 
 # Use a specific version of golang to build both binaries


### PR DESCRIPTION
This PR updates docker-gen to release `0.8.2`.