### PR TITLE
Bump docker-gen from 0.8.4 to 0.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # setup build arguments for version of dependencies to use
-ARG DOCKER_GEN_VERSION=0.8.4
+ARG DOCKER_GEN_VERSION=0.9.0
 ARG FOREGO_VERSION=v0.17.0
 
 # Use a specific version of golang to build both binaries
-FROM golang:1.17.8 as gobuilder
+FROM golang:1.18.0 as gobuilder
 
 # Build docker-gen from scratch
 FROM gobuilder as dockergen

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,9 +1,9 @@
 # setup build arguments for version of dependencies to use
-ARG DOCKER_GEN_VERSION=0.8.4
+ARG DOCKER_GEN_VERSION=0.9.0
 ARG FOREGO_VERSION=v0.17.0
 
 # Use a specific version of golang to build both binaries
-FROM golang:1.17.8-alpine as gobuilder
+FROM golang:1.18.0-alpine as gobuilder
 RUN apk add --no-cache git musl-dev
 
 # Build docker-gen from scratch


### PR DESCRIPTION
docker-gen `0.9.0` add template functions from the [sprig library](https://masterminds.github.io/sprig/), (see https://github.com/nginx-proxy/docker-gen/pull/418) along with the new `{{break}}` and `{{continue}}` actions in [text/template](https://pkg.go.dev/text/template).