### PR TITLE
Make sure networks order is the same

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -105,7 +105,7 @@ upstream {{ .Upstream }} {
             {{ end }}
         {{ end }}
 		{{ range $knownNetwork := $networks }}
-			{{ range $containerNetwork := $container.Networks }}
+			{{ range $containerNetwork := sortObjectsByKeysAsc $container.Networks "Name" }}
 				{{ if (and (ne $containerNetwork.Name "ingress") (or (eq $knownNetwork.Name $containerNetwork.Name) (eq $knownNetwork.Name "host"))) }}
         ## Can be connected with "{{ $containerNetwork.Name }}" network
                     {{ if $address }}

--- a/test/test_vhost-in-multiple-networks.py
+++ b/test/test_vhost-in-multiple-networks.py
@@ -1,0 +1,29 @@
+import pytest
+import logging
+import time
+
+def test_forwards_to_web1(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://web1.nginx-proxy.local/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 81\n"
+
+def test_nginx_config_remains_the_same_after_restart(docker_compose, nginxproxy):
+    """
+    Restarts the Web container and returns nginx-proxy config after restart
+    """
+    def get_conf_after_web_container_restart():
+        web_containers = docker_compose.containers.list(filters={"ancestor": "web:latest"})
+        assert len(web_containers) == 1
+        web_containers[0].restart()
+        time.sleep(3)
+
+        return nginxproxy.get_conf()
+
+    config_before_restart = nginxproxy.get_conf()
+
+    for i in range(1, 8):
+        logging.info(f"Checking for the {i}-st time that config is the same")
+        config_after_restart = get_conf_after_web_container_restart()
+        if config_before_restart != config_after_restart:
+            logging.debug(f"{config_before_restart!r} \n\n {config_after_restart!r}")
+            pytest.fail("nginx-proxy config before and after restart of a web container does not match", pytrace=False)

--- a/test/test_vhost-in-multiple-networks.yml
+++ b/test/test_vhost-in-multiple-networks.yml
@@ -1,0 +1,26 @@
+version: '2'
+
+networks:
+  net1: {}
+  net2: {}
+  net3: {}
+
+services:
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    networks:
+      - net1
+
+  web:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: web1.nginx-proxy.local
+    networks:
+      - net1
+      - net2
+      - net3


### PR DESCRIPTION
Whenever **docker-gen** catches a new event, it tries to generate a new **nginx.conf**, even when an event is unrelated to the proxied containers.

Since **DockerClient** does not guarantee the order in a `Container.Networks` list, each config re-generation may result in a different order of debug messages in the **upstream** section. 

For example, the first run will produce the following config:

```nginx
upstream web.example.com {
        ## Can be connected with "nginx-proxy-network" network
        # web_nginx_1
        server 172.16.1.10:80;
        # Cannot connect to network 'net2' of this container
        # Cannot connect to network 'net3' of this container
}
```

While some other time the order will be different:

```nginx
upstream web.example.com {
        # Cannot connect to network 'net2' of this container
        ## Can be connected with "nginx-proxy-network" network
        # web_nginx_1
        server 172.16.1.10:80;
        # Cannot connect to network 'net3' of this container
}
```

When there are hundreds of containers starting/stopping in a Docker, it leads to a lot of useless Nginx reloads.