### PR TITLE
Expose containers using host networking if they have their VIRTUAL_PORT variable set

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -125,6 +125,10 @@ upstream {{ .Upstream }} {
                         {{ if $containerNetwork.IP }}
                             {{ $server_found = "true" }}
         server {{ $containerNetwork.IP }}:{{ $port }};
+                        {{/* The container is in the host network and wants to be exposed */}}
+                        {{ else if (and $container.Env.VIRTUAL_PORT (eq $containerNetwork.Name "host")) }}
+                            {{ $server_found = "true" }}
+        server 127.0.0.1:{{ $port }};
                         {{ else }}
         # /!\ No IP for this network!
                     	{{ end }}


### PR DESCRIPTION
Hi! I'd like to solve the case when nginx-proxy and another container that's supposed to be exposed by the proxy both use host networking.

Currently the `nginx.tmpl` emits the fallback entry for such container, i.e.:
```
# Fallback entry
server 127.0.0.1 down;
```

The patch I'm proposing will emit:
```
server 127.0.0.1:VIRTUAL_PORT
```

_Note: I'm trying to solve a use case where I need to run a docker container with host networking because the application that runs inside of the container needs to communicate on arbitrary UDP ports (and exposing all UDP port is neither practical nor possible). The application also exposes a REST API on a TCP port and I'd like to use nginx-proxy as a front-end for the API (because of TLS and all the other fancy stuff offered by nginx)._