### PR TITLE
Update nginx.tmpl

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -51,38 +51,44 @@
 {{ end }}
 
 {{ define "location" }}
-	location {{ .Path }} {
-	{{ if eq .NetworkTag "internal" }}
-		# Only allow traffic from internal clients
-		include /etc/nginx/network_internal.conf;
-	{{ end }}
-
-	{{ if eq .Proto "uwsgi" }}
-		include uwsgi_params;
-		uwsgi_pass {{ trim .Proto }}://{{ trim .Upstream }};
-	{{ else if eq .Proto "fastcgi" }}
-		root   {{ trim .VhostRoot }};
-		include fastcgi_params;
-		fastcgi_pass {{ trim .Upstream }};
-	{{ else if eq .Proto "grpc" }}
-		grpc_pass {{ trim .Proto }}://{{ trim .Upstream }};
+	{{ if eq .Proto "custome" }}
+		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" .Host)) }}
+            include {{ printf "/etc/nginx/vhost.d/%s_location" .Host }};
+        {{ end }}
 	{{ else }}
-		proxy_pass {{ trim .Proto }}://{{ trim .Upstream }}{{ trim .Dest }};
-	{{ end }}
+		location {{ .Path }} {
+		{{ if eq .NetworkTag "internal" }}
+			# Only allow traffic from internal clients
+			include /etc/nginx/network_internal.conf;
+		{{ end }}
 
-	{{ if (exists (printf "/etc/nginx/htpasswd/%s" .Host)) }}
-		auth_basic	"Restricted {{ .Host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" .Host) }};
-	{{ end }}
+		{{ if eq .Proto "uwsgi" }}
+			include uwsgi_params;
+			uwsgi_pass {{ trim .Proto }}://{{ trim .Upstream }};
+		{{ else if eq .Proto "fastcgi" }}
+			root   {{ trim .VhostRoot }};
+			include fastcgi_params;
+			fastcgi_pass {{ trim .Upstream }};
+		{{ else if eq .Proto "grpc" }}
+			grpc_pass {{ trim .Proto }}://{{ trim .Upstream }};
+		{{ else }}
+			proxy_pass {{ trim .Proto }}://{{ trim .Upstream }}{{ trim .Dest }};
+		{{ end }}
 
-	{{ if (exists (printf "/etc/nginx/vhost.d/%s_%s_location" .Host (sha1 .Path) )) }}
-		include {{ printf "/etc/nginx/vhost.d/%s_%s_location" .Host (sha1 .Path) }};
-	{{ else if (exists (printf "/etc/nginx/vhost.d/%s_location" .Host)) }}
-		include {{ printf "/etc/nginx/vhost.d/%s_location" .Host}};
-	{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
-		include /etc/nginx/vhost.d/default_location;
+		{{ if (exists (printf "/etc/nginx/htpasswd/%s" .Host)) }}
+			auth_basic	"Restricted {{ .Host }}";
+			auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" .Host) }};
+		{{ end }}
+
+		{{ if (exists (printf "/etc/nginx/vhost.d/%s_%s_location" .Host (sha1 .Path) )) }}
+			include {{ printf "/etc/nginx/vhost.d/%s_%s_location" .Host (sha1 .Path) }};
+		{{ else if (exists (printf "/etc/nginx/vhost.d/%s_location" .Host)) }}
+			include {{ printf "/etc/nginx/vhost.d/%s_location" .Host }};
+		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+			include /etc/nginx/vhost.d/default_location;
+		{{ end }}
+		}
 	{{ end }}
-}
 {{ end }}
 
 {{ define "upstream" }}


### PR DESCRIPTION
- Add VIRTUAL_PROTO=custome

When proto is custome, All `location` shoud be define in `/etc/nginx/vhost.d/`, such as `/etc/nginx/vhost.d/domain.com_location`

That's very usefull when working with php-fpm.

for example of wordpress:

```
version: '3.1'

networks:
  work-net:
    external: true
      
services:

  wordpress:
    image: wordpress:fpm-alpine
    restart: always
    environment:
      - WORDPRESS_DB_HOST=xx.xx.xx.xx
      - WORDPRESS_DB_USER=dbuser
      - WORDPRESS_DB_PASSWORD=dbpass
      - WORDPRESS_DB_NAME=dbname
      - VIRTUAL_HOST=blog.xxx.com
      - VIRTUAL_PROTO=custome
      - LETSENCRYPT_HOST=blog.xxx.com
      - SHA1_UPSTREAM_NAME=true
    volumes:
      - /data/blog:/var/www/html
    networks:
      - work-net
```

And we should add a volume in nginx-proxy

```
docker run -d \
 --restart=always \
 --name nginx-proxy \
 --net work-net \
 -p 80:80 \
 -p 443:443 \
 -v certs:/etc/nginx/certs \
 -v vhost:/etc/nginx/vhost.d \
 -v html:/usr/share/nginx/html \
 -v /var/run/docker.sock:/tmp/docker.sock:ro \
 -v /data/blog:/wordpress \
 nginxproxy/nginx-proxy:alpine
```

Then add a file `blog.xxx.com_location` in docker volume vhost with content like this:

```
root   /wordpress/;
index index.php;

location = /favicon.ico {
    log_not_found off;
    access_log off;
}

location = /robots.txt {
    allow all;
    log_not_found off;
    access_log off;
}

location / {
    try_files $uri $uri/ /index.php?$args;
}

location ~ \.php$ {
    fastcgi_pass    blog.xxx.com;
    fastcgi_param   SCRIPT_FILENAME /var/www/html/$fastcgi_script_name;
    fastcgi_param   PATH_INFO       $fastcgi_path_info;
    fastcgi_index   index.php;
    include         fastcgi_params;
}

location ~* ^.+\.(ogg|ogv|svg|svgz|eot|otf|woff|mp4|ttf|rss|atom|jpg|jpeg|gif|png|ico|zip|tgz|gz|rar|bz2|doc|xls|exe|ppt|tar|mid|midi|wav|bmp|rtf)$ {
    access_log off; 
    log_not_found off; 
    expires max;
}

location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
    access_log off; 
    expires max;
    log_not_found off;
}
```

**NOTICE**

`fastcgi_param   SCRIPT_FILENAME /var/www/html/$fastcgi_script_name;`

CAN NOT set to `fastcgi_param   SCRIPT_FILENAME $document_root$fastcgi_script_name;`

because nginx-proxy and php-fpm are **TWO Containers**

nginx-proxy work for static file in `/wordpress` and fpm work for php file in `/var/www/html`

