### PR TITLE
Support vouch-proxy as authentication for exposed services

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,24 @@ docker run -d -p 80:80 -p 443:443 \
 
 You'll need apache2-utils on the machine where you plan to create the htpasswd file. Follow these [instructions](http://httpd.apache.org/docs/2.2/programs/htpasswd.html)
 
+### vouch-proxy Authentication Support
+
+You can also secure your virtual hosts by using the auth_request nginx module in conjunction with the authentication proxy [vouch-proxy](https://github.com/vouch/vouch-proxy)
+
+```yaml
+  authtest:
+    image: nginx
+    container_name: authtest
+    environment:
+      - LETSENCRYPT_HOST=authtest.mydomain.com
+      - VIRTUAL_HOST=authtest.mydomain.com
+      - VIRTUAL_PORT=80
+      - VOUCH_INTERNAL_LOCATION=http://vouch-proxy:9090
+      - VOUCH_EXTERNAL_LOCATION=https://vouch.mydomain.com
+    expose:
+      - "80"
+```
+
 ### Custom Nginx Configuration
 
 If you need to configure Nginx beyond what is possible using environment variables, you can provide custom configuration files on either a proxy-wide or per-`VIRTUAL_HOST` basis.

--- a/README.md
+++ b/README.md
@@ -365,8 +365,8 @@ You'll need apache2-utils on the machine where you plan to create the htpasswd f
 
 You can also secure your virtual hosts by using the auth_request nginx module in conjunction with the authentication proxy [vouch-proxy](https://github.com/vouch/vouch-proxy).
 Set the following variables on the container you want secured:
-VOUCH_INTERNAL_LOCATION - private URL to your vouch-proxy instance, to perform validations again
-VOUCH_EXTERNAL_LOCATION - public URL to your vouch-proxy instance
+VOUCH_PRIVATE_URL - private URL to your vouch-proxy instance, to perform validations again
+VOUCH_PUBLIC_URL - public URL to your vouch-proxy instance
 
 ```yaml
   authtest:
@@ -376,8 +376,8 @@ VOUCH_EXTERNAL_LOCATION - public URL to your vouch-proxy instance
       - LETSENCRYPT_HOST=authtest.mydomain.com
       - VIRTUAL_HOST=authtest.mydomain.com
       - VIRTUAL_PORT=80
-      - VOUCH_INTERNAL_LOCATION=http://vouch-proxy:9090
-      - VOUCH_EXTERNAL_LOCATION=https://vouch.mydomain.com
+      - VOUCH_PRIVATE_URL=http://vouch-proxy:9090
+      - VOUCH_PUBLIC_URL=https://vouch.mydomain.com
     expose:
       - "80"
 ```

--- a/README.md
+++ b/README.md
@@ -363,7 +363,10 @@ You'll need apache2-utils on the machine where you plan to create the htpasswd f
 
 ### vouch-proxy Authentication Support
 
-You can also secure your virtual hosts by using the auth_request nginx module in conjunction with the authentication proxy [vouch-proxy](https://github.com/vouch/vouch-proxy)
+You can also secure your virtual hosts by using the auth_request nginx module in conjunction with the authentication proxy [vouch-proxy](https://github.com/vouch/vouch-proxy).
+Set the following variables on the container you want secured:
+VOUCH_INTERNAL_LOCATION - private URL to your vouch-proxy instance, to perform validations again
+VOUCH_EXTERNAL_LOCATION - public URL to your vouch-proxy instance
 
 ```yaml
   authtest:

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -388,7 +388,7 @@ server {
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
 
-	{{ if $vouch_internal_location }}
+	{{ if ne $vouch_internal_location "" }}
 	auth_request /vouchValidate;
 
 	location = /vouchValidate {
@@ -411,16 +411,13 @@ server {
     }
 	{{ end }}
 
-	{{ if $vouch_external_location }}
+	{{ if ne $vouch_external_location "" }}
 	# if validate returns `401 not authorized` then forward the request to the error401block
 	error_page 401 = @error401;
 
 	location @error401 {
 		# redirect to Vouch Proxy for login
 		return 302 https://{{ $vouch_external_location }}/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
-		# you usually *want* to redirect to Vouch running behind the same Nginx config proteced by https
-		# but to get started you can just forward the end user to the port that vouch is running on
-		# return 302 http://vouch.yourdomain.com:9090/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
 	}
 	{{ end }}
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -417,7 +417,7 @@ server {
 
 	location @error401 {
 		# redirect to Vouch Proxy for login
-		return 302 https://{{ $vouch_external_location }}/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+		return 302 {{ $vouch_external_location }}/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
 	}
 	{{ end }}
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -306,6 +306,12 @@ server {
 {{/* Use the cert specified on the container or fallback to the best vhost match */}}
 {{ $cert := (coalesce $certName $vhostCert) }}
 
+{{/* Get the VOUCH_INTERNAL_LOCATION defined by containers w/ the same vhost, falling back to empty string (use default) */}}
+{{ $vouch_internal_location := or (first (groupByKeys $containers "Env.VOUCH_INTERNAL_LOCATION")) "" }}
+
+{{/* Get the VOUCH_EXTERNAL_LOCATION defined by containers w/ the same vhost, falling back to empty string (use default) */}}
+{{ $vouch_external_location := or (first (groupByKeys $containers "Env.VOUCH_EXTERNAL_LOCATION")) "" }}
+
 {{ $is_https := (and (ne $https_method "nohttps") (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
 {{ if $is_https }}
@@ -380,6 +386,42 @@ server {
 	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
 	{{ else if (exists "/etc/nginx/vhost.d/default") }}
 	include /etc/nginx/vhost.d/default;
+	{{ end }}
+
+	{{ if $vouch_internal_location }}
+	auth_request /vouchValidate;
+
+	location = /vouchValidate {
+		# forward the /validate request to Vouch Proxy
+		proxy_pass {{ $vouch_internal_location }}/validate;
+		# be sure to pass the original host header
+		proxy_set_header Host $http_host;
+
+		# Vouch Proxy only acts on the request headers
+		proxy_pass_request_body off;
+		proxy_set_header Content-Length "";
+
+		# optionally add X-Vouch-User as returned by Vouch Proxy along with the request
+		auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
+
+		# these return values are used by the @error401 call
+		auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
+		auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
+		auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
+    }
+	{{ end }}
+
+	{{ if $vouch_external_location }}
+	# if validate returns `401 not authorized` then forward the request to the error401block
+	error_page 401 = @error401;
+
+	location @error401 {
+		# redirect to Vouch Proxy for login
+		return 302 https://{{ $vouch_external_location }}/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+		# you usually *want* to redirect to Vouch running behind the same Nginx config proteced by https
+		# but to get started you can just forward the end user to the port that vouch is running on
+		# return 302 http://vouch.yourdomain.com:9090/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+	}
 	{{ end }}
 
 	{{ if eq $nPaths 0 }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -306,11 +306,11 @@ server {
 {{/* Use the cert specified on the container or fallback to the best vhost match */}}
 {{ $cert := (coalesce $certName $vhostCert) }}
 
-{{/* Get the VOUCH_INTERNAL_LOCATION defined by containers w/ the same vhost, falling back to empty string (use default) */}}
-{{ $vouch_internal_location := or (first (groupByKeys $containers "Env.VOUCH_INTERNAL_LOCATION")) "" }}
+{{/* Get the VOUCH_PRIVATE_URL defined by containers w/ the same vhost, falling back to empty string (use default) */}}
+{{ $vouch_private_url := or (first (groupByKeys $containers "Env.VOUCH_PRIVATE_URL")) "" }}
 
-{{/* Get the VOUCH_EXTERNAL_LOCATION defined by containers w/ the same vhost, falling back to empty string (use default) */}}
-{{ $vouch_external_location := or (first (groupByKeys $containers "Env.VOUCH_EXTERNAL_LOCATION")) "" }}
+{{/* Get the VOUCH_PUBLIC_URL defined by containers w/ the same vhost, falling back to empty string (use default) */}}
+{{ $vouch_public_url := or (first (groupByKeys $containers "Env.VOUCH_PUBLIC_URL")) "" }}
 
 {{ $is_https := (and (ne $https_method "nohttps") (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
@@ -388,12 +388,12 @@ server {
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
 
-	{{ if ne $vouch_internal_location "" }}
+	{{ if (and (ne $vouch_private_url "") (ne $vouch_public_url "")) }}
 	auth_request /vouchValidate;
 
 	location = /vouchValidate {
 		# forward the /validate request to Vouch Proxy
-		proxy_pass {{ $vouch_internal_location }}/validate;
+		proxy_pass {{ $vouch_private_url }}/validate;
 		# be sure to pass the original host header
 		proxy_set_header Host $http_host;
 
@@ -409,15 +409,13 @@ server {
 		auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
 		auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
     }
-	{{ end }}
 
-	{{ if ne $vouch_external_location "" }}
 	# if validate returns `401 not authorized` then forward the request to the error401block
 	error_page 401 = @error401;
 
 	location @error401 {
 		# redirect to Vouch Proxy for login
-		return 302 {{ $vouch_external_location }}/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+		return 302 {{ $vouch_public_url }}/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
 	}
 	{{ end }}
 


### PR DESCRIPTION
This PR adds support for authenticating to services exposed by nginx-proxy using [vouch-proxy](https://github.com/vouch/vouch-proxy) and the nginx auth_request module.

Authentication is a common enough use case to merit adding support for this over requiring users to configure something like this using custom nginx configuration and shared volumes.

vouch-proxy supports a wide range of login providers for SSO.