### PR TITLE
Added php-fpm backend

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -50,14 +50,17 @@
 	{{ end }}
 {{ end }}
 
+
 {{ define "location" }}
 	location {{ .Path }} {
 	{{ if eq .NetworkTag "internal" }}
 		# Only allow traffic from internal clients
 		include /etc/nginx/network_internal.conf;
 	{{ end }}
-
-	{{ if eq .Proto "uwsgi" }}
+	{{ if eq .Proto "php-fpm" }}
+		root /usr/share/html/{{.Host}};
+    	try_files $uri /index.php$is_args$args;
+	{{ else if eq .Proto "uwsgi" }}
 		include uwsgi_params;
 		uwsgi_pass {{ trim .Proto }}://{{ trim .Upstream }};
 	{{ else if eq .Proto "fastcgi" }}
@@ -82,7 +85,42 @@
 	{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
 		include /etc/nginx/vhost.d/default_location;
 	{{ end }}
-}
+	}
+{{ if eq .Proto "php-fpm" }}
+	location ~ \.php$ {
+		fastcgi_split_path_info ^(.+\.php)(/.+)$;
+		set $path_info $fastcgi_path_info;
+		fastcgi_param PATH_INFO $path_info;
+		fastcgi_index index.php;
+		fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;
+        fastcgi_param  QUERY_STRING       $query_string;
+        fastcgi_param  REQUEST_METHOD     $request_method;
+        fastcgi_param  CONTENT_TYPE       $content_type;
+        fastcgi_param  CONTENT_LENGTH     $content_length;
+
+        fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+        fastcgi_param  REQUEST_URI        $request_uri;
+        fastcgi_param  DOCUMENT_URI       $document_uri;
+        fastcgi_param  DOCUMENT_ROOT      $document_root;
+        fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+        fastcgi_param  REQUEST_SCHEME     $scheme;
+        fastcgi_param  HTTPS              $https if_not_empty;
+
+        fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+        fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
+
+        fastcgi_param  REMOTE_ADDR        $remote_addr;
+        fastcgi_param  REMOTE_PORT        $remote_port;
+        fastcgi_param  SERVER_ADDR        $server_addr;
+        fastcgi_param  SERVER_PORT        $server_port;
+        fastcgi_param  SERVER_NAME        $server_name;
+
+        # PHP only, required if PHP was built with --enable-force-cgi-redirect
+        fastcgi_param  REDIRECT_STATUS    200;
+		root {{ trim .VhostRoot }};
+		fastcgi_pass {{ trim .Upstream }};
+	}
+{{ end }}
 {{ end }}
 
 {{ define "upstream" }}
@@ -290,7 +328,7 @@ server {
 {{ $hsts := or (first (groupByKeys $containers "Env.HSTS")) (or $.Env.HSTS "max-age=31536000") }}
 
 {{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
-{{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
+{{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/html" }}
 
 
 {{/* Get the first cert name defined by containers w/ the same vhost */}}


### PR DESCRIPTION
Static files can be attached at /usr/share/html/$virtual_host served by nginx and php served by fpm