### PR TITLE
Support TCP and UDP proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update \
 
 # Configure Nginx
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
+   && echo "include /etc/nginx/toplevel.conf.d/*.conf;" >> /etc/nginx/nginx.conf \
    && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
    && sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf \
    && mkdir -p '/etc/nginx/dhparam'

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -54,6 +54,7 @@ RUN apk add --no-cache --virtual .run-deps \
 
 # Configure Nginx
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
+   && echo "include /etc/nginx/toplevel.conf.d/*.conf;" >> /etc/nginx/nginx.conf \
    && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
    && sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf \
    && mkdir -p '/etc/nginx/dhparam'

--- a/README.md
+++ b/README.md
@@ -365,6 +365,35 @@ You'll need apache2-utils on the machine where you plan to create the htpasswd f
 
 If you need to configure Nginx beyond what is possible using environment variables, you can provide custom configuration files on either a proxy-wide or per-`VIRTUAL_HOST` basis.
 
+#### TCP and UDP stream support
+
+If you want to proxy non-HTTP traffic, you can use nginx's stream module. Write a configuration file and mount it to `/etc/nginx/toplevel.conf.d`.
+
+```Nginx
+# stream.conf
+stream {
+
+    server {
+        listen     12345;
+        #TCP traffic will be forwarded to the "stream_backend" upstream group
+        proxy_pass stream_backend;
+    }
+
+    server {
+        listen     12346;
+        #TCP traffic will be forwarded to the specified server
+        proxy_pass backend.example.com:12346;
+    }
+
+    server {
+        listen     53 udp;
+        #UDP traffic will be forwarded to the "dns_servers" upstream group
+        proxy_pass dns_servers;
+    }
+    # ...
+}
+```
+
 #### Replacing default proxy settings
 
 If you want to replace the default proxy settings for the nginx container, add a configuration file at `/etc/nginx/proxy.conf`. A file with the default settings would look like this:


### PR DESCRIPTION
Add including to the root of nginx.conf to facilitate adding configuration outside the http module.