### PR TITLE
chore: Pass `--pull` to `docker build` to get fresh images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@
 
 
 build-webserver:
-	docker build -t web test/requirements/web
+	docker build --pull -t web test/requirements/web
 
 build-nginx-proxy-test-debian:
-	docker build --build-arg NGINX_PROXY_VERSION="test" -t nginxproxy/nginx-proxy:test .
+	docker build --pull --build-arg NGINX_PROXY_VERSION="test" -t nginxproxy/nginx-proxy:test .
 
 build-nginx-proxy-test-alpine:
-	docker build --build-arg NGINX_PROXY_VERSION="test" -f Dockerfile.alpine -t nginxproxy/nginx-proxy:test .
+	docker build --pull --build-arg NGINX_PROXY_VERSION="test" -f Dockerfile.alpine -t nginxproxy/nginx-proxy:test .
 
 test-debian: build-webserver build-nginx-proxy-test-debian
 	test/pytest.sh

--- a/test/pytest.sh
+++ b/test/pytest.sh
@@ -14,7 +14,7 @@ DIR=$(cd "${TESTDIR}/.." && pwd) || exit 1
 
 # check requirements
 echo "> Building nginx-proxy-tester image..."
-docker build -t nginx-proxy-tester \
+docker build --pull -t nginx-proxy-tester \
   -f "${TESTDIR}/requirements/Dockerfile-nginx-proxy-tester" \
   "${TESTDIR}/requirements" \
   || exit 1


### PR DESCRIPTION
This is a no-op if the images are already up to date, and it prevents puzzling problems when the images are old.