### PR TITLE
fix: Partially revert "chore: Remove support for legacy swarm"

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -41,6 +41,14 @@
     {{- $ip := "" }}
     #     networks:
     {{- range sortObjectsByKeysAsc $.container.Networks "Name" }}
+        {{- /*
+             * TODO: Only ignore the "ingress" network for Swarm tasks (in case
+             * the user is not using Swarm mode and names a network "ingress").
+             */}}
+        {{- if eq .Name "ingress" }}
+    #         {{ .Name }} (ignored)
+            {{- continue }}
+        {{- end }}
         {{- if and (not (index $.globals.networks .Name)) (not $.globals.networks.host) }}
     #         {{ .Name }} (unreachable)
             {{- continue }}


### PR DESCRIPTION
This partially reverts commit 2494e207843c92a715da3e8e65ed763fd0d2d624 by ignoring any network named "ingress" when searching for a container's IP address.

That commit was technically a backwards-incompatible change: Some users use nginx-proxy with Swarm mode even though it is not fully supported.  In such cases nginx-proxy should ignore the `ingress` network, otherwise nginx will not be able to reach the server (container-to-container traffic apparently doesn't work over the Swarm `ingress` network).

The parts of that commit that examine the `SwarmNode` structure are not reverted here because docker-gen does not currently populate that structure—not even when both docker-gen and the service task container are running on the same manager node.

See discussion #2172