### PR TITLE
ci: maintain GitHub Actions with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/test/requirements"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "ci"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,13 @@ updates:
       prefix: "ci"
     labels:
       - "type/ci"
+
+  # Maintain GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "type/ci"


### PR DESCRIPTION
This PR:
- add GitHub Actions ecosystem to Dependabot
- schedule test suite dependencies check weekly down from daily