### PR TITLE
ci: rename build / publish workflow

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,4 +1,4 @@
-name: DockerHub
+name: Build and publish Docker images
 
 on:
   workflow_dispatch:
@@ -20,6 +20,7 @@ on:
 
 jobs:
   multiarch-build-debian:
+    name: Build and publish Debian image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -81,6 +82,7 @@ jobs:
         run: echo ${{ steps.docker_build_debian.outputs.digest }}
 
   multiarch-build-alpine:
+    name: Build and publish Alpine image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
We're not publishing on DockerHub only, this PR reflects that.