### PR TITLE
build: get docker-gen from pre-built image

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -28,8 +28,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Retrieve version
-        run: echo "GIT_DESCRIBE=$(git describe --tags)" >> $GITHUB_ENV
+      - name: Retrieve nginx-proxy version
+        id: nginx-proxy_version
+        run: echo "VERSION=$(git describe --tags)" >> "$GITHUB_OUTPUT"
 
       - name: Get Docker tags for Debian based image
         id: docker_meta_debian
@@ -67,7 +68,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Retrieve docker-gen version
-        run: echo "DOCKER_GEN_VERSION=$(grep -o -E 'nginxproxy/docker-gen:([0-9x\.]+)' Dockerfile | cut -d ':' -f2)" >> $GITHUB_ENV
+        id: docker-gen_version
+        run: sed -n -e 's;^FROM nginxproxy/docker-gen:\([0-9.]*\).*;VERSION=\1;p' Dockerfile >> "$GITHUB_OUTPUT"
 
       - name: Build and push the Debian based image
         id: docker_build_debian
@@ -76,8 +78,8 @@ jobs:
           context: .
           file: Dockerfile
           build-args: |
-            NGINX_PROXY_VERSION=${{ env.GIT_DESCRIBE }}
-            DOCKER_GEN_VERSION=${{ env.DOCKER_GEN_VERSION }}
+            NGINX_PROXY_VERSION=${{ steps.nginx-proxy_version.outputs.VERSION }}
+            DOCKER_GEN_VERSION=${{ steps.docker-gen_version.outputs.VERSION }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.docker_meta_debian.outputs.tags }}
@@ -95,8 +97,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Retrieve version
-        run: echo "GIT_DESCRIBE=$(git describe --tags)" >> $GITHUB_ENV
+      - name: Retrieve nginx-proxy version
+        id: nginx-proxy_version
+        run: echo "VERSION=$(git describe --tags)" >> "$GITHUB_OUTPUT"
 
       - name: Get Docker tags for Alpine based image
         id: docker_meta_alpine
@@ -135,7 +138,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Retrieve docker-gen version
-        run: echo "DOCKER_GEN_VERSION=$(grep -o -E 'nginxproxy/docker-gen:([0-9x\.]+)' Dockerfile | cut -d ':' -f2)" >> $GITHUB_ENV
+        id: docker-gen_version
+        run: sed -n -e 's;^FROM nginxproxy/docker-gen:\([0-9.]*\).*;VERSION=\1;p' Dockerfile >> "$GITHUB_OUTPUT"
 
       - name: Build and push the Alpine based image
         id: docker_build_alpine
@@ -144,8 +148,8 @@ jobs:
           context: .
           file: Dockerfile.alpine
           build-args: |
-            NGINX_PROXY_VERSION=${{ env.GIT_DESCRIBE }}
-            DOCKER_GEN_VERSION=${{ env.DOCKER_GEN_VERSION }}
+            NGINX_PROXY_VERSION=${{ steps.nginx-proxy_version.outputs.VERSION }}
+            DOCKER_GEN_VERSION=${{ steps.docker-gen_version.outputs.VERSION }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.docker_meta_alpine.outputs.tags }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -66,13 +66,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Retrieve docker-gen version
+        run: echo "DOCKER_GEN_VERSION=$(grep -o -E 'nginxproxy/docker-gen:([0-9x\.]+)' Dockerfile | cut -d ':' -f2)" >> $GITHUB_ENV
+
       - name: Build and push the Debian based image
         id: docker_build_debian
         uses: docker/build-push-action@v4
         with:
           context: .
           file: Dockerfile
-          build-args: NGINX_PROXY_VERSION=${{ env.GIT_DESCRIBE }}
+          build-args: |
+            NGINX_PROXY_VERSION=${{ env.GIT_DESCRIBE }}
+            DOCKER_GEN_VERSION=${{ env.DOCKER_GEN_VERSION }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.docker_meta_debian.outputs.tags }}
@@ -129,13 +134,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Retrieve docker-gen version
+        run: echo "DOCKER_GEN_VERSION=$(grep -o -E 'nginxproxy/docker-gen:([0-9x\.]+)' Dockerfile | cut -d ':' -f2)" >> $GITHUB_ENV
+
       - name: Build and push the Alpine based image
         id: docker_build_alpine
         uses: docker/build-push-action@v4
         with:
           context: .
           file: Dockerfile.alpine
-          build-args: NGINX_PROXY_VERSION=${{ env.GIT_DESCRIBE }}
+          build-args: |
+            NGINX_PROXY_VERSION=${{ env.GIT_DESCRIBE }}
+            DOCKER_GEN_VERSION=${{ env.DOCKER_GEN_VERSION }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.docker_meta_alpine.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,10 @@
 # setup build arguments for version of dependencies to use
-ARG DOCKER_GEN_VERSION=0.10.4
 ARG FOREGO_VERSION=v0.17.0
 
-# Use a specific version of golang to build both binaries
-FROM golang:1.20.3 as gobuilder
-
-# Build docker-gen from scratch
-FROM gobuilder as dockergen
-
-ARG DOCKER_GEN_VERSION
-
-RUN git clone https://github.com/nginx-proxy/docker-gen \
-   && cd /go/docker-gen \
-   && git -c advice.detachedHead=false checkout $DOCKER_GEN_VERSION \
-   && go mod download \
-   && CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.buildVersion=${DOCKER_GEN_VERSION}" ./cmd/docker-gen \
-   && go clean -cache \
-   && mv docker-gen /usr/local/bin/ \
-   && cd - \
-   && rm -rf /go/docker-gen
+FROM nginxproxy/docker-gen:0.10.4-debian AS docker-gen
 
 # Build forego from scratch
-FROM gobuilder as forego
+FROM golang:1.20.3 as forego
 
 ARG FOREGO_VERSION
 
@@ -39,9 +22,9 @@ RUN git clone https://github.com/nginx-proxy/forego/ \
 FROM nginx:1.23.4
 
 ARG NGINX_PROXY_VERSION
-# Add DOCKER_GEN_VERSION environment variable
-# Because some external projects rely on it
-ARG DOCKER_GEN_VERSION
+# Add DOCKER_GEN_VERSION environment variable because 
+# acme-companion rely on it (but the actual value is not important)
+ARG DOCKER_GEN_VERSION="unknown"
 ENV NGINX_PROXY_VERSION=${NGINX_PROXY_VERSION} \
    DOCKER_GEN_VERSION=${DOCKER_GEN_VERSION} \
    DOCKER_HOST=unix:///tmp/docker.sock
@@ -63,7 +46,7 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
 
 # Install Forego + docker-gen
 COPY --from=forego /usr/local/bin/forego /usr/local/bin/forego
-COPY --from=dockergen /usr/local/bin/docker-gen /usr/local/bin/docker-gen
+COPY --from=docker-gen /usr/local/bin/docker-gen /usr/local/bin/docker-gen
 
 COPY network_internal.conf /etc/nginx/
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,32 +1,15 @@
 # setup build arguments for version of dependencies to use
-ARG DOCKER_GEN_VERSION=0.10.4
 ARG FOREGO_VERSION=v0.17.0
 
-# Use a specific version of golang to build both binaries
-FROM golang:1.20.3-alpine as gobuilder
-RUN apk add --no-cache git musl-dev
-
-# Build docker-gen from scratch
-FROM gobuilder as dockergen
-
-ARG DOCKER_GEN_VERSION
-
-RUN git clone https://github.com/nginx-proxy/docker-gen \
-   && cd /go/docker-gen \
-   && git -c advice.detachedHead=false checkout $DOCKER_GEN_VERSION \
-   && go mod download \
-   && CGO_ENABLED=0 go build -ldflags "-X main.buildVersion=${DOCKER_GEN_VERSION}" ./cmd/docker-gen \
-   && go clean -cache \
-   && mv docker-gen /usr/local/bin/ \
-   && cd - \
-   && rm -rf /go/docker-gen
+FROM nginxproxy/docker-gen:0.10.4 AS docker-gen
 
 # Build forego from scratch
-FROM gobuilder as forego
+FROM golang:1.20.3-alpine as forego
 
 ARG FOREGO_VERSION
 
-RUN git clone https://github.com/nginx-proxy/forego/ \
+RUN apk add --no-cache git musl-dev \
+   && git clone https://github.com/nginx-proxy/forego/ \
    && cd /go/forego \
    && git -c advice.detachedHead=false checkout $FOREGO_VERSION \
    && go mod download \
@@ -40,9 +23,9 @@ RUN git clone https://github.com/nginx-proxy/forego/ \
 FROM nginx:1.23.4-alpine
 
 ARG NGINX_PROXY_VERSION
-# Add DOCKER_GEN_VERSION environment variable
-# Because some external projects rely on it
-ARG DOCKER_GEN_VERSION
+# Add DOCKER_GEN_VERSION environment variable because 
+# acme-companion rely on it (but the actual value is not important)
+ARG DOCKER_GEN_VERSION="unknown"
 ENV NGINX_PROXY_VERSION=${NGINX_PROXY_VERSION} \
    DOCKER_GEN_VERSION=${DOCKER_GEN_VERSION} \
    DOCKER_HOST=unix:///tmp/docker.sock
@@ -60,7 +43,7 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
 
 # Install Forego + docker-gen
 COPY --from=forego /usr/local/bin/forego /usr/local/bin/forego
-COPY --from=dockergen /usr/local/bin/docker-gen /usr/local/bin/docker-gen
+COPY --from=docker-gen /usr/local/bin/docker-gen /usr/local/bin/docker-gen
 
 COPY network_internal.conf /etc/nginx/
 


### PR DESCRIPTION
This PR change the Dockerfiles to get the docker-gen binary from the `nginxproxy/docker-gen` image instead of building it, like acme-companion does.

The actual value of `DOCKER_GEN_VERSION` isn't important for acme-companion so we use a placeholder value in the Dockerfiles and let the CI provide the real value as build arg.