### PR TITLE
build: don't install wget inside images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,9 @@ ENV NGINX_PROXY_VERSION=${NGINX_PROXY_VERSION} \
    DOCKER_GEN_VERSION=${DOCKER_GEN_VERSION} \
    DOCKER_HOST=unix:///tmp/docker.sock
 
-# Install wget and install/updates certificates
+# Install/update certificates
 RUN apt-get update \
-   && apt-get install -y -q --no-install-recommends \
-   ca-certificates \
-   wget \
+   && apt-get install -y -q --no-install-recommends ca-certificates \
    && apt-get clean \
    && rm -r /var/lib/apt/lists/*
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -30,9 +30,11 @@ ENV NGINX_PROXY_VERSION=${NGINX_PROXY_VERSION} \
    DOCKER_GEN_VERSION=${DOCKER_GEN_VERSION} \
    DOCKER_HOST=unix:///tmp/docker.sock
 
-# Install wget and install/updates certificates
+# Install dependencies
 RUN apk add --no-cache --virtual .run-deps \
-   ca-certificates bash wget openssl \
+   bash \
+   ca-certificates \
+   openssl \
    && update-ca-certificates
 
 # Configure Nginx


### PR DESCRIPTION
This was only used a (long) while ago to get docker-gen and/or forego binaries.