### PR TITLE
Add support for remote backends via VIRTUAL_IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,38 @@ docker run -d -p 80:80 -p 443:443 \
 
 You'll need apache2-utils on the machine where you plan to create the htpasswd file. Follow these [instructions](http://httpd.apache.org/docs/2.2/programs/htpasswd.html)
 
+### Custom Upstream (Backend) Server Support
+
+When you need to proxy to a different host (e.g. on your LAN network) or to a container with the host mode networking, a dummy container with `VIRTUAL_IP` and `VIRTUAL_PORT` environment variables.
+
+> **Warning**
+> Running a container with the host mode networking can expose its application on external interface(s) bypassing Nginx proxy.
+
+Docker Compose example for a backend running on `10.20.30.40:1234`:
+
+```yaml
+version: '2'
+
+services:
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+
+  custom-upstream:
+    image: busybox
+    entrypoint: tail -f /dev/null # will wait forever
+    restart: always # keep it running after a reboot
+    environment:
+      - VIRTUAL_HOST=foo.bar.com
+      - VIRTUAL_IP=10.20.30.40
+      - VIRTUAL_PORT=1234
+```
+
+
+
 ### Upstream (Backend) Server HTTP Load Balancing Support
 
 > **Warning**

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -91,6 +91,10 @@
     {{- else }}
     #         (none)
     {{- end }}
+    {{- if .container.Env.VIRTUAL_IP }}
+        {{- $ip = .container.Env.VIRTUAL_IP }}
+    #     Using VIRTUAL_IP: {{ $ip }}
+    {{- end }}
     #     IP address: {{ if $ip }}{{ $ip }}{{ else }}(none usable){{ end }}
     {{- $_ := set $ "ip" $ip }}
 {{- end }}


### PR DESCRIPTION
This adds support for non-container upstreams (e.g. somewhere on LAN).
Some time ago I used a patch from #1100 to solve this issue, but current template has changed a lot.
Although running a dummy container for each custom upstream  is a bit hacky, but it keeps same approach for all deployments, implements a feature requested many times, and does this with minimal changes in the template.

This PR may potentially close:
- #832 
- #1937 
- #1191 
- #1474
- #1270
- #1537

Related PRs (some may be hard to merge now, if they are old):
- #1100 
- #1219 
- #1477
- #2222