### PR TITLE
build: get forego from pre-built image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,6 @@
-# setup build arguments for version of dependencies to use
-ARG FOREGO_VERSION=v0.17.0
-
 FROM nginxproxy/docker-gen:0.10.4-debian AS docker-gen
 
-# Build forego from scratch
-FROM golang:1.20.4 as forego
-
-ARG FOREGO_VERSION
-
-RUN git clone https://github.com/nginx-proxy/forego/ \
-   && cd /go/forego \
-   && git -c advice.detachedHead=false checkout $FOREGO_VERSION \
-   && go mod download \
-   && CGO_ENABLED=0 GOOS=linux go build -o forego . \
-   && go clean -cache \
-   && mv forego /usr/local/bin/ \
-   && cd - \
-   && rm -rf /go/forego
+FROM nginxproxy/forego:0.17.1-debian AS forego
 
 # Build the final image
 FROM nginx:1.23.4
@@ -34,7 +18,6 @@ RUN apt-get update \
    && apt-get install -y -q --no-install-recommends ca-certificates \
    && apt-get clean \
    && rm -r /var/lib/apt/lists/*
-
 
 # Configure Nginx
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,23 +1,6 @@
-# setup build arguments for version of dependencies to use
-ARG FOREGO_VERSION=v0.17.0
-
 FROM nginxproxy/docker-gen:0.10.4 AS docker-gen
 
-# Build forego from scratch
-FROM golang:1.20.4-alpine as forego
-
-ARG FOREGO_VERSION
-
-RUN apk add --no-cache git musl-dev \
-   && git clone https://github.com/nginx-proxy/forego/ \
-   && cd /go/forego \
-   && git -c advice.detachedHead=false checkout $FOREGO_VERSION \
-   && go mod download \
-   && CGO_ENABLED=0 go build -o forego . \
-   && go clean -cache \
-   && mv forego /usr/local/bin/ \
-   && cd - \
-   && rm -rf /go/forego
+FROM nginxproxy/forego:0.17.1 AS forego
 
 # Build the final image
 FROM nginx:1.23.4-alpine


### PR DESCRIPTION
Pretty much the same as #2230 but for forego, which now have a pre built image (`nginxproxy/forego`).

The [diff between version `0.17.0` and `0.17.1`](https://github.com/nginx-proxy/forego/compare/v0.17.0...v0.17.1) is pretty much just dependencies maintenance and the new Dockerfiles + GitHub Action workflow required for the images building and publishing.

I don't plan on doing any work on forego beside this and the occasional dependencies bump, so this PR aim is mostly to further simplify nginx-proxy Dockerfiles and get yet another small bump in build speed.