### PR TITLE
fix: always on session cache on HTTPS fallback listener

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -422,11 +422,11 @@ server {
             {{- if $globals.enable_ipv6 }}
     listen [::]:{{ $globals.external_https_port }} ssl http2; {{- /* Do not add `default_server` (see comment above). */}}
             {{- end }}
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
         {{- end }}
     {{ $globals.access_log }}
         {{- if $globals.default_cert_ok }}
-    ssl_session_cache shared:SSL:50m;
-    ssl_session_tickets off;
     ssl_certificate /etc/nginx/certs/default.crt;
     ssl_certificate_key /etc/nginx/certs/default.key;
         {{- else }}


### PR DESCRIPTION
This PR should fix an issue with Secure Renegociation (RFC 5746) [identified](https://github.com/nginx-proxy/nginx-proxy/pull/2186#issuecomment-1533863923) by @SchoNie and introduced in #2186 

That's counterintuitive but it seems like the `ssl_session_cache` must be enabled as soon as there is an active fallback HTTPS listener if we want secure renegociation to work, even if we're going to return a TLS error from the fallback listener.

@SchoNie I tested the PR with both SSL Labs and OpenSSL and it appears to fix the issue, could you confirm ?