### PR TITLE
fix: Replace mDNS .local domain with .internal domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ services:
     expose:
       - "8000"
     environment:
-      - VIRTUAL_HOST=whoami.local
+      - VIRTUAL_HOST=whoami.example
       - VIRTUAL_PORT=8000
 ```
 
 ```console
 docker-compose up
-curl -H "Host: whoami.local" localhost
+curl -H "Host: whoami.example" localhost
 ```
 
 Example output:
@@ -257,7 +257,7 @@ You can demo this pattern with docker-compose:
 
 ```console
 docker-compose --file docker-compose-separate-containers.yml up
-curl -H "Host: whoami.local" localhost
+curl -H "Host: whoami.example" localhost
 ```
 
 Example output:

--- a/docker-compose-separate-containers.yml
+++ b/docker-compose-separate-containers.yml
@@ -21,4 +21,4 @@ services:
   whoami:
     image: jwilder/whoami
     environment:
-      - VIRTUAL_HOST=whoami.local
+      - VIRTUAL_HOST=whoami.example

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,4 @@ services:
   whoami:
     image: jwilder/whoami
     environment:
-      - VIRTUAL_HOST=whoami.local
+      - VIRTUAL_HOST=whoami.example

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -45,10 +45,10 @@ def ipv6(force_ipv6=True):
     Meant to be used as a context manager to force IPv6 sockets:
 
         with ipv6():
-            nginxproxy.get("http://something.nginx-proxy.local")  # force use of IPv6
+            nginxproxy.get("http://something.nginx-proxy.example")  # force use of IPv6
 
         with ipv6(False):
-            nginxproxy.get("http://something.nginx-proxy.local")  # legacy behavior
+            nginxproxy.get("http://something.nginx-proxy.example")  # legacy behavior
 
 
     """

--- a/test/test_composev2.py
+++ b/test/test_composev2.py
@@ -5,6 +5,6 @@ def test_unknown_virtual_host(docker_compose, nginxproxy):
     assert r.status_code == 503
 
 def test_forwards_to_whoami(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 81\n"

--- a/test/test_composev2.yml
+++ b/test/test_composev2.yml
@@ -11,4 +11,4 @@ services:
       - "81"
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: web.nginx-proxy.local
+      VIRTUAL_HOST: web.nginx-proxy.example

--- a/test/test_custom/test_defaults-location.py
+++ b/test/test_custom/test_defaults-location.py
@@ -6,14 +6,14 @@ def test_custom_default_conf_does_not_apply_to_unknown_vhost(docker_compose, ngi
     assert "X-test" not in r.headers
 
 def test_custom_default_conf_applies_to_web1(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web1.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web1.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 81\n"
     assert "X-test" in r.headers
     assert "f00" == r.headers["X-test"]
 
 def test_custom_default_conf_applies_to_web2(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web2.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web2.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 82\n"
     assert "X-test" in r.headers
@@ -21,7 +21,7 @@ def test_custom_default_conf_applies_to_web2(docker_compose, nginxproxy):
 
 
 def test_custom_default_conf_is_overriden_for_web3(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web3.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web3.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 83\n"
     assert "X-test" in r.headers

--- a/test/test_custom/test_defaults-location.yml
+++ b/test/test_custom/test_defaults-location.yml
@@ -3,7 +3,7 @@ nginx-proxy:
   volumes:
     - /var/run/docker.sock:/tmp/docker.sock:ro
     - ./my_custom_proxy_settings.conf:/etc/nginx/vhost.d/default_location:ro
-    - ./my_custom_proxy_settings_bar.conf:/etc/nginx/vhost.d/web3.nginx-proxy.local_location:ro
+    - ./my_custom_proxy_settings_bar.conf:/etc/nginx/vhost.d/web3.nginx-proxy.example_location:ro
 
 web1:
   image: web
@@ -11,7 +11,7 @@ web1:
     - "81"
   environment:
     WEB_PORTS: 81
-    VIRTUAL_HOST: web1.nginx-proxy.local
+    VIRTUAL_HOST: web1.nginx-proxy.example
 
 web2:
   image: web
@@ -19,7 +19,7 @@ web2:
     - "82"
   environment:
     WEB_PORTS: 82
-    VIRTUAL_HOST: web2.nginx-proxy.local
+    VIRTUAL_HOST: web2.nginx-proxy.example
 
 web3:
   image: web
@@ -27,4 +27,4 @@ web3:
     - "83"
   environment:
     WEB_PORTS: 83
-    VIRTUAL_HOST: web3.nginx-proxy.local
+    VIRTUAL_HOST: web3.nginx-proxy.example

--- a/test/test_custom/test_defaults.py
+++ b/test/test_custom/test_defaults.py
@@ -6,14 +6,14 @@ def test_custom_conf_does_not_apply_to_unknown_vhost(docker_compose, nginxproxy)
     assert "X-test" not in r.headers
 
 def test_custom_conf_applies_to_web1(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web1.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web1.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 81\n"
     assert "X-test" in r.headers
     assert "f00" == r.headers["X-test"]
 
 def test_custom_conf_applies_to_web2(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web2.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web2.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 82\n"
     assert "X-test" in r.headers

--- a/test/test_custom/test_defaults.yml
+++ b/test/test_custom/test_defaults.yml
@@ -12,7 +12,7 @@ services:
       - "81"
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: web1.nginx-proxy.local
+      VIRTUAL_HOST: web1.nginx-proxy.example
 
   web2:
     image: web
@@ -20,4 +20,4 @@ services:
       - "82"
     environment:
       WEB_PORTS: 82
-      VIRTUAL_HOST: web2.nginx-proxy.local
+      VIRTUAL_HOST: web2.nginx-proxy.example

--- a/test/test_custom/test_location-per-vhost.py
+++ b/test/test_custom/test_location-per-vhost.py
@@ -6,17 +6,17 @@ def test_custom_conf_does_not_apply_to_unknown_vhost(docker_compose, nginxproxy)
     assert "X-test" not in r.headers
 
 def test_custom_conf_applies_to_web1(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web1.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web1.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 81\n"
     assert "X-test" in r.headers
     assert "f00" == r.headers["X-test"]
 
 def test_custom_conf_does_not_apply_to_web2(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web2.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web2.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 82\n"
     assert "X-test" not in r.headers
 
 def test_custom_block_is_present_in_nginx_generated_conf(docker_compose, nginxproxy):
-    assert b"include /etc/nginx/vhost.d/web1.nginx-proxy.local_location;" in nginxproxy.get_conf()
+    assert b"include /etc/nginx/vhost.d/web1.nginx-proxy.example_location;" in nginxproxy.get_conf()

--- a/test/test_custom/test_location-per-vhost.yml
+++ b/test/test_custom/test_location-per-vhost.yml
@@ -4,7 +4,7 @@ services:
     image: nginxproxy/nginx-proxy:test
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ./my_custom_proxy_settings.conf:/etc/nginx/vhost.d/web1.nginx-proxy.local_location:ro
+      - ./my_custom_proxy_settings.conf:/etc/nginx/vhost.d/web1.nginx-proxy.example_location:ro
 
   web1:
     image: web
@@ -12,7 +12,7 @@ services:
       - "81"
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: web1.nginx-proxy.local
+      VIRTUAL_HOST: web1.nginx-proxy.example
 
   web2:
     image: web
@@ -20,4 +20,4 @@ services:
       - "82"
     environment:
       WEB_PORTS: 82
-      VIRTUAL_HOST: web2.nginx-proxy.local
+      VIRTUAL_HOST: web2.nginx-proxy.example

--- a/test/test_custom/test_per-vhost.py
+++ b/test/test_custom/test_per-vhost.py
@@ -6,14 +6,14 @@ def test_custom_conf_does_not_apply_to_unknown_vhost(docker_compose, nginxproxy)
     assert "X-test" not in r.headers
 
 def test_custom_conf_applies_to_web1(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web1.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web1.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 81\n"
     assert "X-test" in r.headers
     assert "f00" == r.headers["X-test"]
 
 def test_custom_conf_does_not_apply_to_web2(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web2.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web2.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 82\n"
     assert "X-test" not in r.headers

--- a/test/test_custom/test_per-vhost.yml
+++ b/test/test_custom/test_per-vhost.yml
@@ -4,7 +4,7 @@ services:
     image: nginxproxy/nginx-proxy:test
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ./my_custom_proxy_settings.conf:/etc/nginx/vhost.d/web1.nginx-proxy.local:ro
+      - ./my_custom_proxy_settings.conf:/etc/nginx/vhost.d/web1.nginx-proxy.example:ro
 
   web1:
     image: web
@@ -12,7 +12,7 @@ services:
       - "81"
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: web1.nginx-proxy.local
+      VIRTUAL_HOST: web1.nginx-proxy.example
 
   web2:
     image: web
@@ -20,4 +20,4 @@ services:
       - "82"
     environment:
       WEB_PORTS: 82
-      VIRTUAL_HOST: web2.nginx-proxy.local
+      VIRTUAL_HOST: web2.nginx-proxy.example

--- a/test/test_custom/test_proxy-wide.py
+++ b/test/test_custom/test_proxy-wide.py
@@ -6,14 +6,14 @@ def test_custom_conf_does_not_apply_to_unknown_vhost(docker_compose, nginxproxy)
     assert "X-test" not in r.headers
 
 def test_custom_conf_applies_to_web1(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web1.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web1.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 81\n"
     assert "X-test" in r.headers
     assert "f00" == r.headers["X-test"]
 
 def test_custom_conf_applies_to_web2(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web2.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web2.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 82\n"
     assert "X-test" in r.headers

--- a/test/test_custom/test_proxy-wide.yml
+++ b/test/test_custom/test_proxy-wide.yml
@@ -12,7 +12,7 @@ services:
       - "81"
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: web1.nginx-proxy.local
+      VIRTUAL_HOST: web1.nginx-proxy.example
 
   web2:
     image: web
@@ -20,4 +20,4 @@ services:
       - "82"
     environment:
       WEB_PORTS: 82
-      VIRTUAL_HOST: web2.nginx-proxy.local
+      VIRTUAL_HOST: web2.nginx-proxy.example

--- a/test/test_internal/test_internal-per-vhost.py
+++ b/test/test_internal/test_internal-per-vhost.py
@@ -1,14 +1,14 @@
 import pytest
 
 def test_network_web1(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web1.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web1.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 81\n"
     assert "X-network" in r.headers
     assert "internal" == r.headers["X-network"]
 
 def test_network_web2(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web2.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web2.nginx-proxy.example/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 82\n"
     assert "X-network" not in r.headers

--- a/test/test_internal/test_internal-per-vhost.yml
+++ b/test/test_internal/test_internal-per-vhost.yml
@@ -4,7 +4,7 @@ web1:
     - "81"
   environment:
     WEB_PORTS: 81
-    VIRTUAL_HOST: web1.nginx-proxy.local
+    VIRTUAL_HOST: web1.nginx-proxy.example
     NETWORK_ACCESS: internal
 
 web2:
@@ -13,7 +13,7 @@ web2:
     - "82"
   environment:
     WEB_PORTS: 82
-    VIRTUAL_HOST: web2.nginx-proxy.local
+    VIRTUAL_HOST: web2.nginx-proxy.example
 
 sut:
   image: nginxproxy/nginx-proxy:test

--- a/test/test_internal/test_internal-per-vpath.py
+++ b/test/test_internal/test_internal-per-vpath.py
@@ -1,14 +1,14 @@
 import pytest
 
 def test_network_web1(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://nginx-proxy.local/web1/port")
+    r = nginxproxy.get("http://nginx-proxy.example/web1/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 81\n"
     assert "X-network" in r.headers
     assert "internal" == r.headers["X-network"]
 
 def test_network_web2(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://nginx-proxy.local/web2/port")
+    r = nginxproxy.get("http://nginx-proxy.example/web2/port")
     assert r.status_code == 200   
     assert r.text == "answer from port 82\n"
     assert "X-network" not in r.headers

--- a/test/test_internal/test_internal-per-vpath.yml
+++ b/test/test_internal/test_internal-per-vpath.yml
@@ -4,7 +4,7 @@ web1:
     - "81"
   environment:
     WEB_PORTS: 81
-    VIRTUAL_HOST: nginx-proxy.local
+    VIRTUAL_HOST: nginx-proxy.example
     VIRTUAL_PATH: /web1/
     VIRTUAL_DEST: /
     NETWORK_ACCESS: internal
@@ -15,7 +15,7 @@ web2:
     - "82"
   environment:
     WEB_PORTS: 82
-    VIRTUAL_HOST: nginx-proxy.local
+    VIRTUAL_HOST: nginx-proxy.example
     VIRTUAL_PATH: /web2/
     VIRTUAL_DEST: /
 

--- a/test/test_multiple-networks.py
+++ b/test/test_multiple-networks.py
@@ -8,12 +8,12 @@ def test_unknown_virtual_host(docker_compose, nginxproxy):
     assert r.status_code == 503
 
 def test_forwards_to_web1(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web1.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web1.nginx-proxy.example/port")
     assert r.status_code == 200
     assert r.text == "answer from port 81\n"
 
 def test_forwards_to_web2(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web2.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web2.nginx-proxy.example/port")
     assert r.status_code == 200
     assert r.text == "answer from port 82\n"
 

--- a/test/test_multiple-networks.yml
+++ b/test/test_multiple-networks.yml
@@ -23,7 +23,7 @@ services:
       - "81"
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: web1.nginx-proxy.local
+      VIRTUAL_HOST: web1.nginx-proxy.example
     networks:
       - net1
 
@@ -33,7 +33,7 @@ services:
       - "82"
     environment:
       WEB_PORTS: 82
-      VIRTUAL_HOST: web2.nginx-proxy.local
+      VIRTUAL_HOST: web2.nginx-proxy.example
     networks:
       - net2
 

--- a/test/test_vhost-in-multiple-networks.py
+++ b/test/test_vhost-in-multiple-networks.py
@@ -3,7 +3,7 @@ import logging
 import time
 
 def test_forwards_to_web1(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://web1.nginx-proxy.local/port")
+    r = nginxproxy.get("http://web1.nginx-proxy.example/port")
     assert r.status_code == 200
     assert r.text == "answer from port 81\n"
 

--- a/test/test_vhost-in-multiple-networks.yml
+++ b/test/test_vhost-in-multiple-networks.yml
@@ -19,7 +19,7 @@ services:
       - "81"
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: web1.nginx-proxy.local
+      VIRTUAL_HOST: web1.nginx-proxy.example
     networks:
       - net1
       - net2


### PR DESCRIPTION
Issue: https://github.com/nginx-proxy/nginx-proxy/issues/2249

.local domains are special use domains for mDNS and must not be used for other routing purposes,
use .internal instead in documentation.

See RFC 6762 for details: https://datatracker.ietf.org/doc/html/rfc6762