### PR TITLE
Bump create_server_certificate.sh to nginx:1.25.1

### DIFF
--- a/test/certs/create_server_certificate.sh
+++ b/test/certs/create_server_certificate.sh
@@ -24,7 +24,7 @@ fi
 # Create a nginx container (which conveniently provides the `openssl` command)
 ###############################################################################
 
-CONTAINER=$(docker run -d -v $DIR:/work -w /work -e SAN="$ALTERNATE_DOMAINS" nginx:1.19.10)
+CONTAINER=$(docker run -d -v $DIR:/work -w /work -e SAN="$ALTERNATE_DOMAINS" nginx:1.25.1)
 # Configure openssl
 docker exec $CONTAINER bash -c '
 	mkdir -p /ca/{certs,crl,private,newcerts} 2>/dev/null


### PR DESCRIPTION
Simple version bump of nginx used in create_server_certificate.sh because dependabot will not scan in shell scripts.
Keeping fixed version to avoid unexpected breakage.