### PR TITLE
test: replace python docker-compose with docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ services:
 ```
 
 ```console
-docker-compose up
+docker compose up
 curl -H "Host: whoami.example" localhost
 ```
 
@@ -259,10 +259,10 @@ nginx-proxy can also be run as two separate containers using the [nginxproxy/doc
 
 You may want to do this to prevent having the docker socket bound to a publicly exposed container service.
 
-You can demo this pattern with docker-compose:
+You can demo this pattern with docker compose:
 
 ```console
-docker-compose --file docker-compose-separate-containers.yml up
+docker compose --file docker-compose-separate-containers.yml up
 curl -H "Host: whoami.example" localhost
 ```
 

--- a/docker-compose-separate-containers.yml
+++ b/docker-compose-separate-containers.yml
@@ -1,4 +1,5 @@
-version: '2'
+version: "2"
+
 services:
   nginx:
     image: nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '2'
+version: "2"
+
 services:
   nginx-proxy:
     image: nginxproxy/nginx-proxy

--- a/test/README.md
+++ b/test/README.md
@@ -48,11 +48,11 @@ This test suite uses [pytest](http://doc.pytest.org/en/latest/). The [conftest.p
 
 When using the `docker_compose` fixture in a test, pytest will try to find a yml file named after your test module filename. For instance, if your test module is `test_example.py`, then the `docker_compose` fixture will try to load a `test_example.yml` [docker compose file](https://docs.docker.com/compose/compose-file/).
 
-Once the docker compose file found, the fixture will remove all containers, run `docker-compose up`, and finally your test will be executed.
+Once the docker compose file found, the fixture will remove all containers, run `docker compose up`, and finally your test will be executed.
 
-The fixture will run the _docker-compose_ command with the `-f` option to load the given compose file. So you can test your docker compose file syntax by running it yourself with:
+The fixture will run the _docker compose_ command with the `-f` option to load the given compose file. So you can test your docker compose file syntax by running it yourself with:
 
-    docker-compose -f test_example.yml up -d
+    docker compose -f test_example.yml up -d
 
 In the case you are running pytest from within a docker container, the `docker_compose` fixture will make sure the container running pytest is attached to all docker networks. That way, your test will be able to reach any of them.
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -301,19 +301,19 @@ def get_nginx_conf_from_container(container):
 
 
 def docker_compose_up(compose_file='docker-compose.yml'):
-    logging.info(f'docker-compose -f {compose_file} up -d')
+    logging.info(f'docker compose -f {compose_file} up -d')
     try:
-        subprocess.check_output(shlex.split(f'docker-compose -f {compose_file} up -d'), stderr=subprocess.STDOUT)
+        subprocess.check_output(shlex.split(f'docker compose -f {compose_file} up -d'), stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        pytest.fail(f"Error while runninng 'docker-compose -f {compose_file} up -d':\n{e.output}", pytrace=False)
+        pytest.fail(f"Error while runninng 'docker compose -f {compose_file} up -d':\n{e.output}", pytrace=False)
 
 
 def docker_compose_down(compose_file='docker-compose.yml'):
-    logging.info(f'docker-compose -f {compose_file} down -v')
+    logging.info(f'docker compose -f {compose_file} down -v')
     try:
-        subprocess.check_output(shlex.split(f'docker-compose -f {compose_file} down -v'), stderr=subprocess.STDOUT)
+        subprocess.check_output(shlex.split(f'docker compose -f {compose_file} down -v'), stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        pytest.fail(f"Error while runninng 'docker-compose -f {compose_file} down -v':\n{e.output}", pytrace=False)
+        pytest.fail(f"Error while runninng 'docker compose -f {compose_file} down -v':\n{e.output}", pytrace=False)
 
 
 def wait_for_nginxproxy_to_be_ready():
@@ -333,7 +333,7 @@ def wait_for_nginxproxy_to_be_ready():
 
 @pytest.fixture
 def docker_compose_file(request):
-    """Fixture naming the docker-compose file to consider.
+    """Fixture naming the docker compose file to consider.
 
     If a YAML file exists with the same name as the test module (with the `.py` extension replaced
     with `.yml` or `.yaml`), use that.  Otherwise, use `docker-compose.yml` in the same directory
@@ -354,7 +354,7 @@ def docker_compose_file(request):
         docker_compose_file = default_file
 
     if not os.path.isfile(docker_compose_file):
-        logging.error("Could not find any docker-compose file named either '{0}.yml', '{0}.yaml' or 'docker-compose.yml'".format(request.module.__name__))
+        logging.error("Could not find any docker compose file named either '{0}.yml', '{0}.yaml' or 'docker-compose.yml'".format(request.module.__name__))
 
     logging.debug(f"using docker compose file {docker_compose_file}")
     return docker_compose_file

--- a/test/pytest.sh
+++ b/test/pytest.sh
@@ -19,8 +19,8 @@ docker build --pull -t nginx-proxy-tester \
   "${TESTDIR}/requirements" \
   || exit 1
 
-# run the nginx-proxy-tester container setting the correct value for the working dir in order for
-# docker-compose to work properly when run from within that container.
+# run the nginx-proxy-tester container setting the correct value for the working dir 
+# in order for docker compose to work properly when run from within that container.
 exec docker run --rm -it --name "nginx-proxy-pytest" \
   --volume "/var/run/docker.sock:/var/run/docker.sock" \
   --volume "${DIR}:${DIR}" \

--- a/test/requirements/python-requirements.txt
+++ b/test/requirements/python-requirements.txt
@@ -1,5 +1,4 @@
 backoff==2.2.1
-docker-compose==1.29.2
 docker==6.1.3
 pytest==7.4.3
 requests==2.31.0

--- a/test/stress_tests/test_deleted_cert/docker-compose.yml
+++ b/test/stress_tests/test_deleted_cert/docker-compose.yml
@@ -1,15 +1,17 @@
-web:
-  image: web
-  expose:
-  - "81"
-  environment:
-    WEB_PORTS: 81
-    VIRTUAL_HOST: web.nginx-proxy
+version: "2"
 
+services:
+  web:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: web.nginx-proxy
 
-reverseproxy:
-  image: nginxproxy/nginx-proxy:test
-  container_name: reverseproxy
-  volumes:
-  - /var/run/docker.sock:/tmp/docker.sock:ro
-  - ./tmp_certs:/etc/nginx/certs:ro
+  reverseproxy:
+    image: nginxproxy/nginx-proxy:test
+    container_name: reverseproxy
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./tmp_certs:/etc/nginx/certs:ro

--- a/test/stress_tests/test_unreachable_network/docker-compose.yml
+++ b/test/stress_tests/test_unreachable_network/docker-compose.yml
@@ -32,4 +32,3 @@ services:
     environment:
       WEB_PORTS: 82
       VIRTUAL_HOST: webB.nginx-proxy
-

--- a/test/test_DOCKER_HOST_unix_socket.yml
+++ b/test/test_DOCKER_HOST_unix_socket.yml
@@ -1,23 +1,25 @@
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: 81
-    VIRTUAL_HOST: web1.nginx-proxy.tld
+version: "2"
 
-web2:
-  image: web
-  expose:
-    - "82"
-  environment:
-    WEB_PORTS: 82
-    VIRTUAL_HOST: web2.nginx-proxy.tld
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: web1.nginx-proxy.tld
 
+  web2:
+    image: web
+    expose:
+      - "82"
+    environment:
+      WEB_PORTS: 82
+      VIRTUAL_HOST: web2.nginx-proxy.tld
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/f00.sock:ro
-  environment:
-    DOCKER_HOST: unix:///f00.sock
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/f00.sock:ro
+    environment:
+      DOCKER_HOST: unix:///f00.sock

--- a/test/test_composev2.yml
+++ b/test/test_composev2.yml
@@ -1,4 +1,5 @@
-version: '2'
+version: "2"
+
 services:
   nginx-proxy:
     image: nginxproxy/nginx-proxy:test

--- a/test/test_custom/test_defaults-location.yml
+++ b/test/test_custom/test_defaults-location.yml
@@ -1,30 +1,33 @@
-nginx-proxy:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./my_custom_proxy_settings.conf:/etc/nginx/vhost.d/default_location:ro
-    - ./my_custom_proxy_settings_bar.conf:/etc/nginx/vhost.d/web3.nginx-proxy.example_location:ro
+version: "2"
 
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: 81
-    VIRTUAL_HOST: web1.nginx-proxy.example
+services:
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./my_custom_proxy_settings.conf:/etc/nginx/vhost.d/default_location:ro
+      - ./my_custom_proxy_settings_bar.conf:/etc/nginx/vhost.d/web3.nginx-proxy.example_location:ro
 
-web2:
-  image: web
-  expose:
-    - "82"
-  environment:
-    WEB_PORTS: 82
-    VIRTUAL_HOST: web2.nginx-proxy.example
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: web1.nginx-proxy.example
 
-web3:
-  image: web
-  expose:
-    - "83"
-  environment:
-    WEB_PORTS: 83
-    VIRTUAL_HOST: web3.nginx-proxy.example
+  web2:
+    image: web
+    expose:
+      - "82"
+    environment:
+      WEB_PORTS: 82
+      VIRTUAL_HOST: web2.nginx-proxy.example
+
+  web3:
+    image: web
+    expose:
+      - "83"
+    environment:
+      WEB_PORTS: 83
+      VIRTUAL_HOST: web3.nginx-proxy.example

--- a/test/test_custom/test_defaults.yml
+++ b/test/test_custom/test_defaults.yml
@@ -1,4 +1,5 @@
-version: '2'
+version: "2"
+
 services:
   nginx-proxy:
     image: nginxproxy/nginx-proxy:test

--- a/test/test_custom/test_location-per-vhost.yml
+++ b/test/test_custom/test_location-per-vhost.yml
@@ -1,4 +1,5 @@
-version: '2'
+version: "2"
+
 services:
   nginx-proxy:
     image: nginxproxy/nginx-proxy:test

--- a/test/test_custom/test_per-vhost.yml
+++ b/test/test_custom/test_per-vhost.yml
@@ -1,4 +1,5 @@
-version: '2'
+version: "2"
+
 services:
   nginx-proxy:
     image: nginxproxy/nginx-proxy:test

--- a/test/test_custom/test_proxy-wide.yml
+++ b/test/test_custom/test_proxy-wide.yml
@@ -1,4 +1,5 @@
-version: '2'
+version: "2"
+
 services:
   nginx-proxy:
     image: nginxproxy/nginx-proxy:test

--- a/test/test_default-host.yml
+++ b/test/test_default-host.yml
@@ -1,17 +1,19 @@
-# GIVEN a webserver with VIRTUAL_HOST set to web1.tld
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: 81
-    VIRTUAL_HOST: web1.tld
+version: "2"
 
+services:
+  # GIVEN a webserver with VIRTUAL_HOST set to web1.tld
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: web1.tld
 
-# WHEN nginx-proxy runs with DEFAULT_HOST set to web1.tld
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-  environment:
-    DEFAULT_HOST: web1.tld
+  # WHEN nginx-proxy runs with DEFAULT_HOST set to web1.tld
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    environment:
+      DEFAULT_HOST: web1.tld

--- a/test/test_default-root-none.yml
+++ b/test/test_default-root-none.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 services:
   sut:
     image: nginxproxy/nginx-proxy:test
@@ -5,6 +7,7 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     environment:
       DEFAULT_ROOT: none
+
   web:
     image: web
     expose:

--- a/test/test_dockergen/test_dockergen_v2.yml
+++ b/test/test_dockergen/test_dockergen_v2.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 
 services:
   nginx:

--- a/test/test_dockergen/test_dockergen_v3.yml
+++ b/test/test_dockergen/test_dockergen_v3.yml
@@ -1,4 +1,5 @@
-version: '3'
+version: "3"
+
 services:
   nginx:
     image: nginx

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -22,6 +22,7 @@ def web1(docker_compose):
         },
         ports={"81/tcp": None}
     )
+    docker_compose.networks.get("test_default").connect(container)
     sleep(2)  # give it some time to initialize and for docker-gen to detect it
     yield container
     try:
@@ -46,6 +47,7 @@ def web2(docker_compose):
         },
         ports={"82/tcp": None}
     )
+    docker_compose.networks.get("test_default").connect(container)
     sleep(2)  # give it some time to initialize and for docker-gen to detect it
     yield container
     try:

--- a/test/test_events.yml
+++ b/test/test_events.yml
@@ -1,4 +1,7 @@
-nginxproxy:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
+version: "2"
+
+services:
+  nginxproxy:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/test/test_fallback.data/custom-fallback.yml
+++ b/test/test_fallback.data/custom-fallback.yml
@@ -1,9 +1,12 @@
+version: "2"
+
 services:
   sut:
     image: nginxproxy/nginx-proxy:test
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./custom-fallback.conf:/etc/nginx/conf.d/zzz-custom-fallback.conf:ro
+
   http-only:
     image: web
     expose:

--- a/test/test_fallback.data/nodefault.yml
+++ b/test/test_fallback.data/nodefault.yml
@@ -1,9 +1,12 @@
+version: "2"
+
 services:
   sut:
     image: nginxproxy/nginx-proxy:test
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./nodefault.certs:/etc/nginx/certs:ro
+
   https-and-http:
     image: web
     expose:
@@ -11,6 +14,7 @@ services:
     environment:
       WEB_PORTS: "81"
       VIRTUAL_HOST: https-and-http.nginx-proxy.test
+
   https-only:
     image: web
     expose:
@@ -19,6 +23,7 @@ services:
       WEB_PORTS: "82"
       VIRTUAL_HOST: https-only.nginx-proxy.test
       HTTPS_METHOD: nohttp
+
   http-only:
     image: web
     expose:
@@ -27,6 +32,7 @@ services:
       WEB_PORTS: "83"
       VIRTUAL_HOST: http-only.nginx-proxy.test
       HTTPS_METHOD: nohttps
+
   missing-cert:
     image: web
     expose:

--- a/test/test_fallback.data/nohttp-on-app.yml
+++ b/test/test_fallback.data/nohttp-on-app.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 services:
   sut:
     image: nginxproxy/nginx-proxy:test
@@ -6,6 +8,7 @@ services:
       - ./withdefault.certs:/etc/nginx/certs:ro
     environment:
       HTTPS_METHOD: redirect
+
   https-only:
     image: web
     expose:

--- a/test/test_fallback.data/nohttp-with-missing-cert.yml
+++ b/test/test_fallback.data/nohttp-with-missing-cert.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 services:
   sut:
     image: nginxproxy/nginx-proxy:test
@@ -6,6 +8,7 @@ services:
       - ./withdefault.certs:/etc/nginx/certs:ro
     environment:
       HTTPS_METHOD: nohttp
+
   https-only:
     image: web
     expose:
@@ -13,6 +16,7 @@ services:
     environment:
       WEB_PORTS: "82"
       VIRTUAL_HOST: https-only.nginx-proxy.test
+
   missing-cert:
     image: web
     expose:

--- a/test/test_fallback.data/nohttp.yml
+++ b/test/test_fallback.data/nohttp.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 services:
   sut:
     image: nginxproxy/nginx-proxy:test
@@ -6,6 +8,7 @@ services:
       - ./withdefault.certs:/etc/nginx/certs:ro
     environment:
       HTTPS_METHOD: nohttp
+
   https-only:
     image: web
     expose:

--- a/test/test_fallback.data/nohttps-on-app.yml
+++ b/test/test_fallback.data/nohttps-on-app.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 services:
   sut:
     image: nginxproxy/nginx-proxy:test
@@ -5,6 +7,7 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     environment:
       HTTPS_METHOD: redirect
+
   http-only:
     image: web
     expose:

--- a/test/test_fallback.data/nohttps.yml
+++ b/test/test_fallback.data/nohttps.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 services:
   sut:
     image: nginxproxy/nginx-proxy:test
@@ -5,6 +7,7 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     environment:
       HTTPS_METHOD: nohttps
+
   http-only:
     image: web
     expose:

--- a/test/test_fallback.data/withdefault.yml
+++ b/test/test_fallback.data/withdefault.yml
@@ -1,9 +1,12 @@
+version: "2"
+
 services:
   sut:
     image: nginxproxy/nginx-proxy:test
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./withdefault.certs:/etc/nginx/certs:ro
+
   https-and-http:
     image: web
     expose:
@@ -11,6 +14,7 @@ services:
     environment:
       WEB_PORTS: "81"
       VIRTUAL_HOST: https-and-http.nginx-proxy.test
+
   https-only:
     image: web
     expose:
@@ -19,6 +23,7 @@ services:
       WEB_PORTS: "82"
       VIRTUAL_HOST: https-only.nginx-proxy.test
       HTTPS_METHOD: nohttp
+
   http-only:
     image: web
     expose:
@@ -27,6 +32,7 @@ services:
       WEB_PORTS: "83"
       VIRTUAL_HOST: http-only.nginx-proxy.test
       HTTPS_METHOD: nohttps
+
   missing-cert:
     image: web
     expose:

--- a/test/test_headers/test_http.yml
+++ b/test/test_headers/test_http.yml
@@ -1,22 +1,24 @@
-web:
-  image: web
-  expose:
-    - "80"
-  environment:
-    WEB_PORTS: 80
-    VIRTUAL_HOST: web.nginx-proxy.tld
+version: "2"
 
-web-server-tokens-off:
-  image: web
-  expose:
-    - "80"
-  environment:
-    WEB_PORTS: 80
-    VIRTUAL_HOST: web-server-tokens-off.nginx-proxy.tld
-    SERVER_TOKENS: "off"
+services:
+  web:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: 80
+      VIRTUAL_HOST: web.nginx-proxy.tld
 
+  web-server-tokens-off:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: 80
+      VIRTUAL_HOST: web-server-tokens-off.nginx-proxy.tld
+      SERVER_TOKENS: "off"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/test/test_headers/test_https.yml
+++ b/test/test_headers/test_https.yml
@@ -1,28 +1,30 @@
-web:
-  image: web
-  expose:
-    - "80"
-  environment:
-    WEB_PORTS: 80
-    VIRTUAL_HOST: web.nginx-proxy.tld
+version: "2"
 
-web-server-tokens-off:
-  image: web
-  expose:
-    - "80"
-  environment:
-    WEB_PORTS: 80
-    VIRTUAL_HOST: web-server-tokens-off.nginx-proxy.tld
-    SERVER_TOKENS: "off"
+services:
+  web:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: 80
+      VIRTUAL_HOST: web.nginx-proxy.tld
 
+  web-server-tokens-off:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: 80
+      VIRTUAL_HOST: web-server-tokens-off.nginx-proxy.tld
+      SERVER_TOKENS: "off"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./certs/web.nginx-proxy.tld.crt:/etc/nginx/certs/default.crt:ro
-    - ./certs/web.nginx-proxy.tld.key:/etc/nginx/certs/default.key:ro
-    - ./certs/web.nginx-proxy.tld.crt:/etc/nginx/certs/web.nginx-proxy.tld.crt:ro
-    - ./certs/web.nginx-proxy.tld.key:/etc/nginx/certs/web.nginx-proxy.tld.key:ro
-    - ./certs/web-server-tokens-off.nginx-proxy.tld.crt:/etc/nginx/certs/web-server-tokens-off.nginx-proxy.tld.crt:ro
-    - ./certs/web-server-tokens-off.nginx-proxy.tld.key:/etc/nginx/certs/web-server-tokens-off.nginx-proxy.tld.key:ro
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs/web.nginx-proxy.tld.crt:/etc/nginx/certs/default.crt:ro
+      - ./certs/web.nginx-proxy.tld.key:/etc/nginx/certs/default.key:ro
+      - ./certs/web.nginx-proxy.tld.crt:/etc/nginx/certs/web.nginx-proxy.tld.crt:ro
+      - ./certs/web.nginx-proxy.tld.key:/etc/nginx/certs/web.nginx-proxy.tld.key:ro
+      - ./certs/web-server-tokens-off.nginx-proxy.tld.crt:/etc/nginx/certs/web-server-tokens-off.nginx-proxy.tld.crt:ro
+      - ./certs/web-server-tokens-off.nginx-proxy.tld.key:/etc/nginx/certs/web-server-tokens-off.nginx-proxy.tld.key:ro

--- a/test/test_http2/test_http2_global_disabled.yml
+++ b/test/test_http2/test_http2_global_disabled.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 services:
   http2-global-disabled:
     image: web

--- a/test/test_http3/test_http3_global_disabled.yml
+++ b/test/test_http3/test_http3_global_disabled.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 services:
   http3-global-disabled:
     image: web
@@ -12,4 +14,4 @@ services:
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     #environment:
-      #ENABLE_HTTP3: "false"    #Disabled by default
+    #ENABLE_HTTP3: "false"    #Disabled by default

--- a/test/test_http3/test_http3_global_enabled.yml
+++ b/test/test_http3/test_http3_global_enabled.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 services:
   http3-global-enabled:
     image: web

--- a/test/test_http3/test_http3_vhost.yml
+++ b/test/test_http3/test_http3_vhost.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 services:
   http3-vhost-enabled:
     image: web

--- a/test/test_http_port.yml
+++ b/test/test_http_port.yml
@@ -1,14 +1,17 @@
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "*.nginx-proxy.tld"
+version: "2"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-  environment:
-    HTTP_PORT: 8080
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "*.nginx-proxy.tld"
+
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    environment:
+      HTTP_PORT: 8080

--- a/test/test_internal/test_internal-per-vhost.yml
+++ b/test/test_internal/test_internal-per-vhost.yml
@@ -1,23 +1,25 @@
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: 81
-    VIRTUAL_HOST: web1.nginx-proxy.example
-    NETWORK_ACCESS: internal
+version: "2"
 
-web2:
-  image: web
-  expose:
-    - "82"
-  environment:
-    WEB_PORTS: 82
-    VIRTUAL_HOST: web2.nginx-proxy.example
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: web1.nginx-proxy.example
+      NETWORK_ACCESS: internal
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./network_internal.conf:/etc/nginx/network_internal.conf:ro
+  web2:
+    image: web
+    expose:
+      - "82"
+    environment:
+      WEB_PORTS: 82
+      VIRTUAL_HOST: web2.nginx-proxy.example
 
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./network_internal.conf:/etc/nginx/network_internal.conf:ro

--- a/test/test_internal/test_internal-per-vpath.yml
+++ b/test/test_internal/test_internal-per-vpath.yml
@@ -1,27 +1,29 @@
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: 81
-    VIRTUAL_HOST: nginx-proxy.example
-    VIRTUAL_PATH: /web1/
-    VIRTUAL_DEST: /
-    NETWORK_ACCESS: internal
+version: "2"
 
-web2:
-  image: web
-  expose:
-    - "82"
-  environment:
-    WEB_PORTS: 82
-    VIRTUAL_HOST: nginx-proxy.example
-    VIRTUAL_PATH: /web2/
-    VIRTUAL_DEST: /
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: nginx-proxy.example
+      VIRTUAL_PATH: /web1/
+      VIRTUAL_DEST: /
+      NETWORK_ACCESS: internal
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./network_internal.conf:/etc/nginx/network_internal.conf:ro
+  web2:
+    image: web
+    expose:
+      - "82"
+    environment:
+      WEB_PORTS: 82
+      VIRTUAL_HOST: nginx-proxy.example
+      VIRTUAL_PATH: /web2/
+      VIRTUAL_DEST: /
 
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./network_internal.conf:/etc/nginx/network_internal.conf:ro

--- a/test/test_ipv6.yml
+++ b/test/test_ipv6.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 
 networks:
   net1:
@@ -27,7 +27,6 @@ services:
       VIRTUAL_HOST: web2.nginx-proxy.tld
     networks:
       - net1
-
 
   sut:
     image: nginxproxy/nginx-proxy:test

--- a/test/test_keepalive.yml
+++ b/test/test_keepalive.yml
@@ -1,25 +1,27 @@
-keepalive-disabled:
-  image: web
-  expose:
-    - "80"
-  environment:
-    WEB_PORTS: 80
-    VIRTUAL_HOST: keepalive-disabled.nginx-proxy.test
+version: "2"
 
-keepalive-enabled:
-  image: web
-  expose:
-    - "80"
-  environment:
-    WEB_PORTS: 80
-    VIRTUAL_HOST: keepalive-enabled.nginx-proxy.test
-  labels:
-    com.github.nginx-proxy.nginx-proxy.keepalive: "64"
+services:
+  keepalive-disabled:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: 80
+      VIRTUAL_HOST: keepalive-disabled.nginx-proxy.test
 
+  keepalive-enabled:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: 80
+      VIRTUAL_HOST: keepalive-enabled.nginx-proxy.test
+    labels:
+      com.github.nginx-proxy.nginx-proxy.keepalive: "64"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-  environment:
-    HTTPS_METHOD: nohttps
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    environment:
+      HTTPS_METHOD: nohttps

--- a/test/test_loadbalancing.yml
+++ b/test/test_loadbalancing.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 services:
   loadbalance-hash:
     image: web

--- a/test/test_location-override.yml
+++ b/test/test_location-override.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 services:
   sut:
     image: nginxproxy/nginx-proxy:test

--- a/test/test_log_format.yml
+++ b/test/test_log_format.yml
@@ -1,15 +1,18 @@
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: 81
-    VIRTUAL_HOST: nginx-proxy.test
+version: "2"
 
-sut:
-  container_name: sut
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-  environment:
-    LOG_FORMAT: "$$remote_addr - $$remote_user [$$time_local] \"$$request\" $$status $$body_bytes_sent \"$$http_referer\" \"$$http_user_agent\" request_time=$$request_time $$upstream_response_time"
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: nginx-proxy.test
+
+  sut:
+    container_name: sut
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    environment:
+      LOG_FORMAT: '$$remote_addr - $$remote_user [$$time_local] "$$request" $$status $$body_bytes_sent "$$http_referer" "$$http_user_agent" request_time=$$request_time $$upstream_response_time'

--- a/test/test_multiple-hosts.yml
+++ b/test/test_multiple-hosts.yml
@@ -1,13 +1,15 @@
-web:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: 81
-    VIRTUAL_HOST: webA.nginx-proxy.tld,webB.nginx-proxy.tld
+version: "2"
 
+services:
+  web:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: webA.nginx-proxy.tld,webB.nginx-proxy.tld
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/test/test_multiple-networks.yml
+++ b/test/test_multiple-networks.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 
 networks:
   net1: {}

--- a/test/test_multiple-ports/test_VIRTUAL_PORT-single-different-from-single-port.yml
+++ b/test/test_multiple-ports/test_VIRTUAL_PORT-single-different-from-single-port.yml
@@ -1,14 +1,16 @@
-web:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "web.nginx-proxy.tld"
-    VIRTUAL_PORT: "90"
+version: "2"
 
+services:
+  web:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "web.nginx-proxy.tld"
+      VIRTUAL_PORT: "90"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/test/test_multiple-ports/test_VIRTUAL_PORT.yml
+++ b/test/test_multiple-ports/test_VIRTUAL_PORT.yml
@@ -1,14 +1,17 @@
-web:
-  image: web
-  expose:
-    - "80"
-    - "90"
-  environment:
-    WEB_PORTS: "80 90"
-    VIRTUAL_HOST: "web.nginx-proxy.tld"
-    VIRTUAL_PORT: 90
+version: "2"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
+services:
+  web:
+    image: web
+    expose:
+      - "80"
+      - "90"
+    environment:
+      WEB_PORTS: "80 90"
+      VIRTUAL_HOST: "web.nginx-proxy.tld"
+      VIRTUAL_PORT: 90
+
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/test/test_multiple-ports/test_default-80.yml
+++ b/test/test_multiple-ports/test_default-80.yml
@@ -1,13 +1,16 @@
-web:
-  image: web
-  expose:
-    - "80"
-    - "81"
-  environment:
-    WEB_PORTS: "80 81"
-    VIRTUAL_HOST: "web.nginx-proxy.tld"
+version: "2"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
+services:
+  web:
+    image: web
+    expose:
+      - "80"
+      - "81"
+    environment:
+      WEB_PORTS: "80 81"
+      VIRTUAL_HOST: "web.nginx-proxy.tld"
+
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/test/test_multiple-ports/test_single-port-not-80.yml
+++ b/test/test_multiple-ports/test_single-port-not-80.yml
@@ -1,13 +1,15 @@
-web:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "web.nginx-proxy.tld"
+version: "2"
 
+services:
+  web:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "web.nginx-proxy.tld"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/test/test_nominal.yml
+++ b/test/test_nominal.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 
 networks:
   net1:
@@ -27,7 +27,6 @@ services:
       VIRTUAL_HOST: web2.nginx-proxy.tld
     networks:
       - net1
-
 
   sut:
     image: nginxproxy/nginx-proxy:test

--- a/test/test_raw-ip-vhost.yml
+++ b/test/test_raw-ip-vhost.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 
 networks:
   net1:
@@ -6,7 +6,7 @@ networks:
     ipam:
       config:
         - subnet: 172.20.0.0/16
-        - subnet: fd00::/80  
+        - subnet: fd00::/80
 
 services:
   web1:

--- a/test/test_server-down/test_load-balancing.yml
+++ b/test/test_server-down/test_load-balancing.yml
@@ -1,29 +1,32 @@
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: 81
-    VIRTUAL_HOST: web.nginx-proxy.tld
+version: "2"
 
-web2:
-  image: web
-  expose:
-    - "82"
-  environment:
-    WEB_PORTS: 83
-    VIRTUAL_HOST: web.nginx-proxy.tld
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: web.nginx-proxy.tld
 
-web3:
-  image: web
-  expose:
-    - "83"
-  environment:
-    WEB_PORTS: 83
-    VIRTUAL_HOST: web.nginx-proxy.tld
-  net: "none"
+  web2:
+    image: web
+    expose:
+      - "82"
+    environment:
+      WEB_PORTS: 83
+      VIRTUAL_HOST: web.nginx-proxy.tld
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
+  web3:
+    image: web
+    expose:
+      - "83"
+    environment:
+      WEB_PORTS: 83
+      VIRTUAL_HOST: web.nginx-proxy.tld
+    net: "none"
+
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/test/test_server-down/test_load-balancing.yml
+++ b/test/test_server-down/test_load-balancing.yml
@@ -24,7 +24,7 @@ services:
     environment:
       WEB_PORTS: 83
       VIRTUAL_HOST: web.nginx-proxy.tld
-    net: "none"
+    network_mode: "none"
 
   sut:
     image: nginxproxy/nginx-proxy:test

--- a/test/test_server-down/test_no-server-down.yml
+++ b/test/test_server-down/test_no-server-down.yml
@@ -1,12 +1,15 @@
-web:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: 81
-    VIRTUAL_HOST: web.nginx-proxy.tld
+version: "2"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
+services:
+  web:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: web.nginx-proxy.tld
+
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/test/test_server-down/test_server-down.yml
+++ b/test/test_server-down/test_server-down.yml
@@ -8,7 +8,7 @@ services:
     environment:
       WEB_PORTS: 81
       VIRTUAL_HOST: web.nginx-proxy.tld
-    net: "none"
+    network_mode: "none"
 
   sut:
     image: nginxproxy/nginx-proxy:test

--- a/test/test_server-down/test_server-down.yml
+++ b/test/test_server-down/test_server-down.yml
@@ -1,13 +1,16 @@
-web:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: 81
-    VIRTUAL_HOST: web.nginx-proxy.tld
-  net: "none"
+version: "2"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
+services:
+  web:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: web.nginx-proxy.tld
+    net: "none"
+
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/test/test_ssl/test_dhparam.yml
+++ b/test/test_ssl/test_dhparam.yml
@@ -1,73 +1,75 @@
-web5:
-  image: web
-  expose:
-    - "85"
-  environment:
-    WEB_PORTS: "85"
-    VIRTUAL_HOST: "web5.nginx-proxy.tld"
+version: "2"
 
-# Intended for testing with `dh-file` container.
-# VIRTUAL_HOST is paired with site-specific DH param file.
-# DEFAULT_HOST is required to avoid defaulting to web2,
-# if not specifying FQDN (`-servername`) in openssl queries.
-web2:
-  image: web
-  expose:
-    - "85"
-  environment:
-    WEB_PORTS: "85"
-    VIRTUAL_HOST: "web2.nginx-proxy.tld"
+services:
+  web5:
+    image: web
+    expose:
+      - "85"
+    environment:
+      WEB_PORTS: "85"
+      VIRTUAL_HOST: "web5.nginx-proxy.tld"
 
+  # Intended for testing with `dh-file` container.
+  # VIRTUAL_HOST is paired with site-specific DH param file.
+  # DEFAULT_HOST is required to avoid defaulting to web2,
+  # if not specifying FQDN (`-servername`) in openssl queries.
+  web2:
+    image: web
+    expose:
+      - "85"
+    environment:
+      WEB_PORTS: "85"
+      VIRTUAL_HOST: "web2.nginx-proxy.tld"
 
-# sut - System Under Test
-# `docker.sock` required for functionality
-# `certs` required to enable HTTPS via template
-with_default_group:
-  container_name: dh-default
-  image: &img-nginxproxy nginxproxy/nginx-proxy:test
-  environment: &env-common
-    - &default-host DEFAULT_HOST=web5.nginx-proxy.tld
-  volumes: &vols-common
-    - &docker-sock /var/run/docker.sock:/tmp/docker.sock:ro
-    - &nginx-certs ./certs:/etc/nginx/certs:ro
+  # sut - System Under Test
+  # `docker.sock` required for functionality
+  # `certs` required to enable HTTPS via template
+  with_default_group:
+    container_name: dh-default
+    image: &img-nginxproxy nginxproxy/nginx-proxy:test
+    environment: &env-common
+      - &default-host DEFAULT_HOST=web5.nginx-proxy.tld
+    volumes: &vols-common
+      - &docker-sock /var/run/docker.sock:/tmp/docker.sock:ro
+      - &nginx-certs ./certs:/etc/nginx/certs:ro
 
-with_alternative_group:
-  container_name: dh-env
-  environment:
-    - DHPARAM_BITS=3072
-    - *default-host
-  image: *img-nginxproxy
-  volumes: *vols-common
+  with_alternative_group:
+    container_name: dh-env
+    environment:
+      - DHPARAM_BITS=3072
+      - *default-host
+    image: *img-nginxproxy
+    volumes: *vols-common
 
-with_invalid_group:
-  container_name: invalid-group-1024
-  environment:
-    - DHPARAM_BITS=1024
-    - *default-host
-  image: *img-nginxproxy
-  volumes: *vols-common
+  with_invalid_group:
+    container_name: invalid-group-1024
+    environment:
+      - DHPARAM_BITS=1024
+      - *default-host
+    image: *img-nginxproxy
+    volumes: *vols-common
 
-with_custom_file:
-  container_name: dh-file
-  image: *img-nginxproxy
-  environment: *env-common
-  volumes:
-    - *docker-sock
-    - *nginx-certs
-    - ../../app/dhparam/ffdhe3072.pem:/etc/nginx/dhparam/dhparam.pem:ro
+  with_custom_file:
+    container_name: dh-file
+    image: *img-nginxproxy
+    environment: *env-common
+    volumes:
+      - *docker-sock
+      - *nginx-certs
+      - ../../app/dhparam/ffdhe3072.pem:/etc/nginx/dhparam/dhparam.pem:ro
 
-with_skip:
-  container_name: dh-skip
-  environment:
-    - DHPARAM_SKIP=true
-    - *default-host
-  image: *img-nginxproxy
-  volumes: *vols-common
+  with_skip:
+    container_name: dh-skip
+    environment:
+      - DHPARAM_SKIP=true
+      - *default-host
+    image: *img-nginxproxy
+    volumes: *vols-common
 
-with_skip_backward:
-  container_name: dh-skip-backward
-  environment:
-    - DHPARAM_GENERATION=false
-    - *default-host
-  image: *img-nginxproxy
-  volumes: *vols-common
+  with_skip_backward:
+    container_name: dh-skip-backward
+    environment:
+      - DHPARAM_GENERATION=false
+      - *default-host
+    image: *img-nginxproxy
+    volumes: *vols-common

--- a/test/test_ssl/test_hsts.yml
+++ b/test/test_ssl/test_hsts.yml
@@ -1,51 +1,54 @@
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "web1.nginx-proxy.tld"
+version: "2"
 
-web2:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "web2.nginx-proxy.tld"
-    HSTS: "off"
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "web1.nginx-proxy.tld"
 
-web3:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "web3.nginx-proxy.tld"
-    HSTS: "max-age=86400; includeSubDomains; preload"
+  web2:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "web2.nginx-proxy.tld"
+      HSTS: "off"
 
-web4:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "web4.nginx-proxy.tld"
-    HSTS: "off"
-    HTTPS_METHOD: "noredirect"
+  web3:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "web3.nginx-proxy.tld"
+      HSTS: "max-age=86400; includeSubDomains; preload"
 
-web5:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: http3-vhost-enabled.nginx-proxy.tld
-  labels:
-    com.github.nginx-proxy.nginx-proxy.http3.enable: "true"
+  web4:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "web4.nginx-proxy.tld"
+      HSTS: "off"
+      HTTPS_METHOD: "noredirect"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./certs:/etc/nginx/certs:ro
+  web5:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: http3-vhost-enabled.nginx-proxy.tld
+    labels:
+      com.github.nginx-proxy.nginx-proxy.http3.enable: "true"
+
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs:/etc/nginx/certs:ro

--- a/test/test_ssl/test_https_port.yml
+++ b/test/test_ssl/test_https_port.yml
@@ -1,16 +1,19 @@
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "*.nginx-proxy.tld"
+version: "2"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./certs:/etc/nginx/certs:ro
-  environment:
-    HTTP_PORT: 8080
-    HTTPS_PORT: 8443
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "*.nginx-proxy.tld"
+
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs:/etc/nginx/certs:ro
+    environment:
+      HTTP_PORT: 8080
+      HTTPS_PORT: 8443

--- a/test/test_ssl/test_nohttp.yml
+++ b/test/test_ssl/test_nohttp.yml
@@ -1,15 +1,17 @@
-web2:
-  image: web
-  expose:
-    - "82"
-  environment:
-    WEB_PORTS: "82"
-    VIRTUAL_HOST: "web2.nginx-proxy.tld"
-    HTTPS_METHOD: nohttp
+version: "2"
 
+services:
+  web2:
+    image: web
+    expose:
+      - "82"
+    environment:
+      WEB_PORTS: "82"
+      VIRTUAL_HOST: "web2.nginx-proxy.tld"
+      HTTPS_METHOD: nohttp
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./certs:/etc/nginx/certs:ro
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs:/etc/nginx/certs:ro

--- a/test/test_ssl/test_nohttps.yml
+++ b/test/test_ssl/test_nohttps.yml
@@ -1,14 +1,16 @@
-web:
-  image: web
-  expose:
-    - "83"
-  environment:
-    WEB_PORTS: "83"
-    VIRTUAL_HOST: "web.nginx-proxy.tld"
-    HTTPS_METHOD: nohttps
+version: "2"
 
+services:
+  web:
+    image: web
+    expose:
+      - "83"
+    environment:
+      WEB_PORTS: "83"
+      VIRTUAL_HOST: "web.nginx-proxy.tld"
+      HTTPS_METHOD: nohttps
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/test/test_ssl/test_noredirect.yml
+++ b/test/test_ssl/test_noredirect.yml
@@ -1,15 +1,17 @@
-web3:
-  image: web
-  expose:
-    - "83"
-  environment:
-    WEB_PORTS: "83"
-    VIRTUAL_HOST: "web3.nginx-proxy.tld"
-    HTTPS_METHOD: noredirect
+version: "2"
 
+services:
+  web3:
+    image: web
+    expose:
+      - "83"
+    environment:
+      WEB_PORTS: "83"
+      VIRTUAL_HOST: "web3.nginx-proxy.tld"
+      HTTPS_METHOD: noredirect
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./certs:/etc/nginx/certs:ro
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs:/etc/nginx/certs:ro

--- a/test/test_ssl/test_virtual_path.yml
+++ b/test/test_ssl/test_virtual_path.yml
@@ -1,26 +1,28 @@
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "www.nginx-proxy.tld"
-    VIRTUAL_PATH: "/web1/"
-    VIRTUAL_DEST: "/"
+version: "2"
 
-web2:
-  image: web
-  expose:
-    - "82"
-  environment:
-    WEB_PORTS: "82"
-    VIRTUAL_HOST: "www.nginx-proxy.tld"
-    VIRTUAL_PATH: "/web2/"
-    VIRTUAL_DEST: "/"
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "www.nginx-proxy.tld"
+      VIRTUAL_PATH: "/web1/"
+      VIRTUAL_DEST: "/"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./certs:/etc/nginx/certs:ro
+  web2:
+    image: web
+    expose:
+      - "82"
+    environment:
+      WEB_PORTS: "82"
+      VIRTUAL_HOST: "www.nginx-proxy.tld"
+      VIRTUAL_PATH: "/web2/"
+      VIRTUAL_DEST: "/"
 
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs:/etc/nginx/certs:ro

--- a/test/test_ssl/test_wildcard.yml
+++ b/test/test_ssl/test_wildcard.yml
@@ -1,13 +1,16 @@
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "*.nginx-proxy.tld"
+version: "2"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./certs:/etc/nginx/certs:ro
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "*.nginx-proxy.tld"
+
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs:/etc/nginx/certs:ro

--- a/test/test_trust-downstream-proxy/test_default.yml
+++ b/test/test_trust-downstream-proxy/test_default.yml
@@ -1,16 +1,18 @@
-web:
-  image: web
-  expose:
-    - "80"
-  environment:
-    WEB_PORTS: 80
-    VIRTUAL_HOST: web.nginx-proxy.tld
-    HTTPS_METHOD: noredirect
+version: "2"
 
+services:
+  web:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: 80
+      VIRTUAL_HOST: web.nginx-proxy.tld
+      HTTPS_METHOD: noredirect
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./certs/web.nginx-proxy.tld.crt:/etc/nginx/certs/web.nginx-proxy.tld.crt:ro
-    - ./certs/web.nginx-proxy.tld.key:/etc/nginx/certs/web.nginx-proxy.tld.key:ro
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs/web.nginx-proxy.tld.crt:/etc/nginx/certs/web.nginx-proxy.tld.crt:ro
+      - ./certs/web.nginx-proxy.tld.key:/etc/nginx/certs/web.nginx-proxy.tld.key:ro

--- a/test/test_trust-downstream-proxy/test_disabled.yml
+++ b/test/test_trust-downstream-proxy/test_disabled.yml
@@ -1,18 +1,20 @@
-web:
-  image: web
-  expose:
-    - "80"
-  environment:
-    WEB_PORTS: 80
-    VIRTUAL_HOST: web.nginx-proxy.tld
-    HTTPS_METHOD: noredirect
+version: "2"
 
+services:
+  web:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: 80
+      VIRTUAL_HOST: web.nginx-proxy.tld
+      HTTPS_METHOD: noredirect
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  environment:
-    TRUST_DOWNSTREAM_PROXY: "false"
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./certs/web.nginx-proxy.tld.crt:/etc/nginx/certs/web.nginx-proxy.tld.crt:ro
-    - ./certs/web.nginx-proxy.tld.key:/etc/nginx/certs/web.nginx-proxy.tld.key:ro
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    environment:
+      TRUST_DOWNSTREAM_PROXY: "false"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs/web.nginx-proxy.tld.crt:/etc/nginx/certs/web.nginx-proxy.tld.crt:ro
+      - ./certs/web.nginx-proxy.tld.key:/etc/nginx/certs/web.nginx-proxy.tld.key:ro

--- a/test/test_trust-downstream-proxy/test_enabled.yml
+++ b/test/test_trust-downstream-proxy/test_enabled.yml
@@ -1,18 +1,20 @@
-web:
-  image: web
-  expose:
-    - "80"
-  environment:
-    WEB_PORTS: 80
-    VIRTUAL_HOST: web.nginx-proxy.tld
-    HTTPS_METHOD: noredirect
+version: "2"
 
+services:
+  web:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: 80
+      VIRTUAL_HOST: web.nginx-proxy.tld
+      HTTPS_METHOD: noredirect
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  environment:
-    TRUST_DOWNSTREAM_PROXY: "true"
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./certs/web.nginx-proxy.tld.crt:/etc/nginx/certs/web.nginx-proxy.tld.crt:ro
-    - ./certs/web.nginx-proxy.tld.key:/etc/nginx/certs/web.nginx-proxy.tld.key:ro
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    environment:
+      TRUST_DOWNSTREAM_PROXY: "true"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs/web.nginx-proxy.tld.crt:/etc/nginx/certs/web.nginx-proxy.tld.crt:ro
+      - ./certs/web.nginx-proxy.tld.key:/etc/nginx/certs/web.nginx-proxy.tld.key:ro

--- a/test/test_upstream-name/test_predictable-name.yml
+++ b/test/test_upstream-name/test_predictable-name.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 
 services:
   web:

--- a/test/test_upstream-name/test_sha1-name.yml
+++ b/test/test_upstream-name/test_sha1-name.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 
 services:
   web:

--- a/test/test_vhost-empty-string.yml
+++ b/test/test_vhost-empty-string.yml
@@ -1,8 +1,11 @@
+version: "2"
+
 services:
   sut:
     image: nginxproxy/nginx-proxy:test
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
+
   web1:
     image: web
     expose:
@@ -11,6 +14,7 @@ services:
       WEB_PORTS: "81"
       # The space is intentional (should be trimmed).
       VIRTUAL_HOST: " "
+
   web2:
     image: web
     expose:
@@ -19,6 +23,7 @@ services:
       WEB_PORTS: "82"
       # The space is intentional (should be trimmed).
       VIRTUAL_HOST: "web2.nginx-proxy.test ,"
+
   web3:
     image: web
     expose:
@@ -27,6 +32,7 @@ services:
       WEB_PORTS: "83"
       # The space is intentional (should be trimmed).
       VIRTUAL_HOST: " ,web3.nginx-proxy.test"
+
   web4:
     image: web
     expose:

--- a/test/test_vhost-in-multiple-networks.yml
+++ b/test/test_vhost-in-multiple-networks.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 
 networks:
   net1: {}

--- a/test/test_virtual-path/test_custom_conf.yml
+++ b/test/test_virtual-path/test_custom_conf.yml
@@ -1,48 +1,49 @@
+version: "2"
 
-foo:
-  image: web
-  expose:
-    - "42"
-  environment:
-    WEB_PORTS: "42"
-    VIRTUAL_HOST: "foo.nginx-proxy.test"
+services:
+  foo:
+    image: web
+    expose:
+      - "42"
+    environment:
+      WEB_PORTS: "42"
+      VIRTUAL_HOST: "foo.nginx-proxy.test"
 
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "nginx-proxy.test"
-    VIRTUAL_PATH: "/web1/"
-    VIRTUAL_DEST: "/"
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "nginx-proxy.test"
+      VIRTUAL_PATH: "/web1/"
+      VIRTUAL_DEST: "/"
 
-web2:
-  image: web
-  expose:
-    - "82"
-  environment:
-    WEB_PORTS: "82"
-    VIRTUAL_HOST: "nginx-proxy.test"
-    VIRTUAL_PATH: "/web2/"
-    VIRTUAL_DEST: "/"
+  web2:
+    image: web
+    expose:
+      - "82"
+    environment:
+      WEB_PORTS: "82"
+      VIRTUAL_HOST: "nginx-proxy.test"
+      VIRTUAL_PATH: "/web2/"
+      VIRTUAL_DEST: "/"
 
-web3:
-  image: web
-  expose:
-    - "83"
-  environment:
-    WEB_PORTS: "83"
-    VIRTUAL_HOST: "nginx-proxy.test"
-    VIRTUAL_PATH: "~ ^/(web3|alt)/"
+  web3:
+    image: web
+    expose:
+      - "83"
+    environment:
+      WEB_PORTS: "83"
+      VIRTUAL_HOST: "nginx-proxy.test"
+      VIRTUAL_PATH: "~ ^/(web3|alt)/"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  environment:
-    DEFAULT_ROOT: 418
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./foo.conf:/etc/nginx/vhost.d/foo.nginx-proxy.test:ro
-    - ./bar.conf:/etc/nginx/vhost.d/nginx-proxy.test_918d687a929083edd0c7224ee2293e0e7c062ab4_location:ro
-    - ./alternate.conf:/etc/nginx/vhost.d/nginx-proxy.test_7fb22b74bbdf907425dbbad18e4462565cada230_location:ro
-
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    environment:
+      DEFAULT_ROOT: 418
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./foo.conf:/etc/nginx/vhost.d/foo.nginx-proxy.test:ro
+      - ./bar.conf:/etc/nginx/vhost.d/nginx-proxy.test_918d687a929083edd0c7224ee2293e0e7c062ab4_location:ro
+      - ./alternate.conf:/etc/nginx/vhost.d/nginx-proxy.test_7fb22b74bbdf907425dbbad18e4462565cada230_location:ro

--- a/test/test_virtual-path/test_forwarding.yml
+++ b/test/test_virtual-path/test_forwarding.yml
@@ -1,17 +1,20 @@
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "www.nginx-proxy.tld"
-    VIRTUAL_PATH: "/web1/"
-    VIRTUAL_DEST: "/"
+version: "2"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./certs:/etc/nginx/certs:ro
-  environment:
-    - DEFAULT_ROOT=301 http://$$host/web1$$request_uri
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "www.nginx-proxy.tld"
+      VIRTUAL_PATH: "/web1/"
+      VIRTUAL_DEST: "/"
+
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs:/etc/nginx/certs:ro
+    environment:
+      - DEFAULT_ROOT=301 http://$$host/web1$$request_uri

--- a/test/test_virtual-path/test_location_precedence.yml
+++ b/test/test_virtual-path/test_location_precedence.yml
@@ -1,37 +1,40 @@
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "foo.nginx-proxy.test"
-    VIRTUAL_PATH: "/web1/"
-    VIRTUAL_DEST: "/"
+version: "2"
 
-web2:
-  image: web
-  expose:
-    - "82"
-  environment:
-    WEB_PORTS: "82"
-    VIRTUAL_HOST: "bar.nginx-proxy.test"
-    VIRTUAL_PATH: "/web2/"
-    VIRTUAL_DEST: "/"
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "foo.nginx-proxy.test"
+      VIRTUAL_PATH: "/web1/"
+      VIRTUAL_DEST: "/"
 
-web3:
-  image: web
-  expose:
-    - "83"
-  environment:
-    WEB_PORTS: "83"
-    VIRTUAL_HOST: "bar.nginx-proxy.test"
-    VIRTUAL_PATH: "/web3/"
-    VIRTUAL_DEST: "/"
+  web2:
+    image: web
+    expose:
+      - "82"
+    environment:
+      WEB_PORTS: "82"
+      VIRTUAL_HOST: "bar.nginx-proxy.test"
+      VIRTUAL_PATH: "/web2/"
+      VIRTUAL_DEST: "/"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./default.conf:/etc/nginx/vhost.d/default_location:ro
-    - ./host.conf:/etc/nginx/vhost.d/bar.nginx-proxy.test_location:ro
-    - ./path.conf:/etc/nginx/vhost.d/bar.nginx-proxy.test_99f2db0ed8aa95dbb5b87fca79c7eff2ff6bb8bd_location:ro
+  web3:
+    image: web
+    expose:
+      - "83"
+    environment:
+      WEB_PORTS: "83"
+      VIRTUAL_HOST: "bar.nginx-proxy.test"
+      VIRTUAL_PATH: "/web3/"
+      VIRTUAL_DEST: "/"
+
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./default.conf:/etc/nginx/vhost.d/default_location:ro
+      - ./host.conf:/etc/nginx/vhost.d/bar.nginx-proxy.test_location:ro
+      - ./path.conf:/etc/nginx/vhost.d/bar.nginx-proxy.test_99f2db0ed8aa95dbb5b87fca79c7eff2ff6bb8bd_location:ro

--- a/test/test_virtual-path/test_virtual_paths.py
+++ b/test/test_virtual-path/test_virtual_paths.py
@@ -39,6 +39,7 @@ def web4(docker_compose):
         },
         ports={"84/tcp": None}
     )
+    docker_compose.networks.get("test_virtual-path_default").connect(container)
     sleep(2)  # give it some time to initialize and for docker-gen to detect it
     yield container
     try:

--- a/test/test_virtual-path/test_virtual_paths.yml
+++ b/test/test_virtual-path/test_virtual_paths.yml
@@ -1,42 +1,44 @@
+version: "2"
 
-foo:
-  image: web
-  expose:
-    - "42"
-  environment:
-    WEB_PORTS: "42"
-    VIRTUAL_HOST: "foo.nginx-proxy.test"
+services:
+  foo:
+    image: web
+    expose:
+      - "42"
+    environment:
+      WEB_PORTS: "42"
+      VIRTUAL_HOST: "foo.nginx-proxy.test"
 
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "nginx-proxy.test"
-    VIRTUAL_PATH: "/web1/"
-    VIRTUAL_DEST: "/"
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "nginx-proxy.test"
+      VIRTUAL_PATH: "/web1/"
+      VIRTUAL_DEST: "/"
 
-web2:
-  image: web
-  expose:
-    - "82"
-  environment:
-    WEB_PORTS: "82"
-    VIRTUAL_HOST: "nginx-proxy.test"
-    VIRTUAL_PATH: "/web2/"
-    VIRTUAL_DEST: "/"
+  web2:
+    image: web
+    expose:
+      - "82"
+    environment:
+      WEB_PORTS: "82"
+      VIRTUAL_HOST: "nginx-proxy.test"
+      VIRTUAL_PATH: "/web2/"
+      VIRTUAL_DEST: "/"
 
-web3:
-  image: web
-  expose:
-    - "83"
-  environment:
-    WEB_PORTS: "83"
-    VIRTUAL_HOST: "nginx-proxy.test"
-    VIRTUAL_PATH: "/"
+  web3:
+    image: web
+    expose:
+      - "83"
+    environment:
+      WEB_PORTS: "83"
+      VIRTUAL_HOST: "nginx-proxy.test"
+      VIRTUAL_PATH: "/"
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/test/test_wildcard_host.yml
+++ b/test/test_wildcard_host.yml
@@ -28,7 +28,7 @@ web4:
     - "84"
   environment:
     WEB_PORTS: "84"
-    VIRTUAL_HOST: ~^web4\..*\.nginx-proxy\.regexp$$ # we need to double the `$` because of docker-compose variable interpolation
+    VIRTUAL_HOST: ~^web4\..*\.nginx-proxy\.regexp$$ # we need to double the `$` because of docker compose variable interpolation
 
 
 sut:

--- a/test/test_wildcard_host.yml
+++ b/test/test_wildcard_host.yml
@@ -1,37 +1,39 @@
-web1:
-  image: web
-  expose:
-    - "81"
-  environment:
-    WEB_PORTS: "81"
-    VIRTUAL_HOST: "*.nginx-proxy.test"
+version: "2"
 
-web2:
-  image: web
-  expose:
-    - "82"
-  environment:
-    WEB_PORTS: "82"
-    VIRTUAL_HOST: "test.nginx-proxy.*"
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "*.nginx-proxy.test"
 
-web3:
-  image: web
-  expose:
-    - "83"
-  environment:
-    WEB_PORTS: "83"
-    VIRTUAL_HOST: ~^web3\..*\.nginx-proxy\.regexp
+  web2:
+    image: web
+    expose:
+      - "82"
+    environment:
+      WEB_PORTS: "82"
+      VIRTUAL_HOST: "test.nginx-proxy.*"
 
-web4:
-  image: web
-  expose:
-    - "84"
-  environment:
-    WEB_PORTS: "84"
-    VIRTUAL_HOST: ~^web4\..*\.nginx-proxy\.regexp$$ # we need to double the `$` because of docker compose variable interpolation
+  web3:
+    image: web
+    expose:
+      - "83"
+    environment:
+      WEB_PORTS: "83"
+      VIRTUAL_HOST: ~^web3\..*\.nginx-proxy\.regexp
 
+  web4:
+    image: web
+    expose:
+      - "84"
+    environment:
+      WEB_PORTS: "84"
+      VIRTUAL_HOST: ~^web4\..*\.nginx-proxy\.regexp$$ # we need to double the `$` because of docker compose variable interpolation
 
-sut:
-  image: nginxproxy/nginx-proxy:test
-  volumes:
-    - /var/run/docker.sock:/tmp/docker.sock:ro
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro


### PR DESCRIPTION
This PR get rid of the deprecated Python `docker-compose` in favor of the now built in command `docker compose`.

This means that all docker compose test files must be at least valid compose v2 files, which pretty much all of them weren't.