### PR TITLE
fix #2310

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -75,7 +75,7 @@
                 {{- continue }}
             {{- end }}
             {{- range sortObjectsByKeysAsc $.globals.CurrentContainer.Networks "Name" }}
-                {{- if and . .Gateway }}
+                {{- if and . .Gateway (not .Internal) }}
     #         container is in host network mode, using {{ .Name }} gateway IP
                     {{- $ip = .Gateway }}
                     {{- break }}


### PR DESCRIPTION
Check the '.Internal' network property, because the .Gateway property is defined for internal networks as well.