### PR TITLE
Pytest color terminal output

### DIFF
--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 # disable the creation of the `.cache` folders
-addopts = -p no:cacheprovider --ignore=requirements --ignore=certs -r s -v
+addopts = -p no:cacheprovider --ignore=requirements --ignore=certs --color=yes -v
 markers =
     incremental: mark a test as incremental.


### PR DESCRIPTION
- Pretty terminal output colors.
- Remove obsolete "-r s" which is there to hide "Skipped" tests from summary text. But seems to be of no use as there are no skipped tests.
