### PR TITLE
Fix xpass and xfails test_restart_while_missing_cert.py

### DIFF
--- a/test/stress_tests/test_deleted_cert/test_restart_while_missing_cert.py
+++ b/test/stress_tests/test_deleted_cert/test_restart_while_missing_cert.py
@@ -46,7 +46,7 @@ def test_https_web_is_200(docker_compose, nginxproxy):
 def test_delete_cert_and_restart_reverseproxy(docker_compose):
     os.remove(join(script_dir, "tmp_certs", "web.nginx-proxy.crt"))
     docker_compose.containers.get("reverseproxy").restart()
-    sleep(3)  # give time for the container to initialize
+    sleep(5)  # give time for the container to initialize
     assert "running" == docker_compose.containers.get("reverseproxy").status
 
 

--- a/test/stress_tests/test_deleted_cert/test_restart_while_missing_cert.py
+++ b/test/stress_tests/test_deleted_cert/test_restart_while_missing_cert.py
@@ -9,8 +9,6 @@ from requests import ConnectionError
 
 script_dir = os.path.dirname(__file__)
 
-pytestmark = pytest.mark.xfail()  # TODO delete this marker once those issues are fixed
-
 @pytest.fixture(scope="module", autouse=True)
 def certs():
     """
@@ -45,7 +43,6 @@ def test_https_web_is_200(docker_compose, nginxproxy):
     assert "answer from port 81\n" in r.text
 
 
-@pytest.mark.incremental
 def test_delete_cert_and_restart_reverseproxy(docker_compose):
     os.remove(join(script_dir, "tmp_certs", "web.nginx-proxy.crt"))
     docker_compose.containers.get("reverseproxy").restart()
@@ -53,20 +50,17 @@ def test_delete_cert_and_restart_reverseproxy(docker_compose):
     assert "running" == docker_compose.containers.get("reverseproxy").status
 
 
-@pytest.mark.incremental
-def test_unknown_virtual_host_is_still_503(nginxproxy):
+def test_unknown_virtual_host_is_still_503(docker_compose, nginxproxy):
     r = nginxproxy.get("http://foo.nginx-proxy/")
     assert r.status_code == 503
 
 
-@pytest.mark.incremental
-def test_http_web_is_now_200(nginxproxy):
+def test_http_web_is_now_200(docker_compose, nginxproxy):
     r = nginxproxy.get("http://web.nginx-proxy/port", allow_redirects=False)
     assert r.status_code == 200
     assert "answer from port 81\n" == r.text
 
 
-@pytest.mark.incremental
 def test_https_web_is_now_broken_since_there_is_no_cert(nginxproxy):
     with pytest.raises(ConnectionError):
         nginxproxy.get("https://web.nginx-proxy/port")


### PR DESCRIPTION
Tests in `stress_tests\test_restart_while_missing_cert.py` were being marked as xfailed and some others are partial. But I do not see a special reason. (nor could find in the commit history).
So I removed the xfail and incremental markers. And fixed 2 tests.

Now CI should have 100% passed score.

If there was a reason they should be xfail / xpass where I was not aware off just delete this PR.