### PR TITLE
feat: enable proxy_buffering

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -556,7 +556,6 @@ If you want to replace the default proxy settings for the nginx container, add a
 ```Nginx
 # HTTP 1.1 support
 proxy_http_version 1.1;
-proxy_buffering off;
 proxy_set_header Host $http_host;
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header Connection $proxy_connection;

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -402,7 +402,6 @@ include /etc/nginx/proxy.conf;
 {{- else }}
 # HTTP 1.1 support
 proxy_http_version 1.1;
-proxy_buffering off;
 proxy_set_header Host $host;
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header Connection $proxy_connection;


### PR DESCRIPTION
[nginx strongly discourage using the `proxy_buffering off` directive.](https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#proxy_buffering-off), treating it as a straight on mistake.

> We’re surprised by how often we see `proxy_buffering off` in configurations. Perhaps it is intended to reduce the latency experienced by clients, but the effect is negligible while the side effects are numerous: with proxy buffering disabled, rate limiting and caching don’t work even if configured, performance suffers, and so on.
> 
> There are only a small number of use cases where disabling proxy buffering might make sense (such as long polling), so we strongly discourage changing the default.

It was added over 9 years ago in response to #1 (https://github.com/nginx-proxy/nginx-proxy/commit/11faa5f2400611be9f0e9b75bb8c31681bee37cf), seemingly fixing this issue but without any real explanation as to what the root cause was and why this was the accepted fix. I highly doubt that this issue persist today and that proxy_buffering alone truncate responses over 32k.