### PR TITLE
refactor: cleanup dockerfiles

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -21,8 +21,7 @@ RUN apk add --no-cache --virtual .run-deps \
    && update-ca-certificates
 
 # Configure Nginx
-RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
-   && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
+RUN sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
    && sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf \
    && mkdir -p '/etc/nginx/dhparam'
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -21,8 +21,7 @@ RUN apk add --no-cache --virtual .run-deps \
    && update-ca-certificates
 
 # Configure Nginx
-RUN sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
-   && sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf \
+RUN sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf \
    && mkdir -p '/etc/nginx/dhparam'
 
 # Install Forego + docker-gen

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -14,11 +14,7 @@ ENV NGINX_PROXY_VERSION=${NGINX_PROXY_VERSION} \
    DOCKER_HOST=unix:///tmp/docker.sock
 
 # Install dependencies
-RUN apk add --no-cache --virtual .run-deps \
-   bash \
-   ca-certificates \
-   openssl \
-   && update-ca-certificates
+RUN apk add --no-cache --virtual .run-deps bash
 
 # Configure Nginx
 RUN sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -20,8 +20,7 @@ RUN apt-get update \
    && rm -r /var/lib/apt/lists/*
 
 # Configure Nginx
-RUN sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
-   && sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf \
+RUN sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf \
    && mkdir -p '/etc/nginx/dhparam'
 
 # Install Forego + docker-gen

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -13,12 +13,6 @@ ENV NGINX_PROXY_VERSION=${NGINX_PROXY_VERSION} \
    DOCKER_GEN_VERSION=${DOCKER_GEN_VERSION} \
    DOCKER_HOST=unix:///tmp/docker.sock
 
-# Install/update certificates
-RUN apt-get update \
-   && apt-get install -y -q --no-install-recommends ca-certificates \
-   && apt-get clean \
-   && rm -r /var/lib/apt/lists/*
-
 # Configure Nginx
 RUN sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf \
    && mkdir -p '/etc/nginx/dhparam'

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -20,8 +20,7 @@ RUN apt-get update \
    && rm -r /var/lib/apt/lists/*
 
 # Configure Nginx
-RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
-   && sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
+RUN sed -i 's/worker_processes  1/worker_processes  auto/' /etc/nginx/nginx.conf \
    && sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf \
    && mkdir -p '/etc/nginx/dhparam'
 

--- a/app/Procfile
+++ b/app/Procfile
@@ -1,2 +1,2 @@
 dockergen: docker-gen -watch -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
-nginx: nginx
+nginx: nginx -g "daemon off;"


### PR DESCRIPTION
This PR remove unneeded stuff from the Dockerfiles:
- rather than adding `daemon off;` to `/etc/nginx/nginx.conf`, start nginx with `-g "daemon off;"` on the procfile
- upstream `/etc/nginx/nginx.conf` already has `worker_processes auto;`, no need to edit the file for this
- upstream image already has up to date `ca-certificates`
- `openssl` is not a required dependency for either image