### PR TITLE
test: install docker compose in nginx-proxy-tester image

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -4,11 +4,9 @@ Nginx proxy test suite
 Install requirements
 --------------------
 
-You need [python 3.9](https://www.python.org/) and [pip](https://pip.pypa.io/en/stable/installing/) installed. Then run the commands:
+You need [Docker Compose v2](https://docs.docker.com/compose/install/linux/), [python 3.9](https://www.python.org/) and [pip](https://pip.pypa.io/en/stable/installation/)  installed. Then run the commands:
 
     pip install -r requirements/python-requirements.txt
-
-
 
 Prepare the nginx-proxy test image
 ----------------------------------
@@ -37,6 +35,16 @@ Run one single test module
 
     pytest test_nominal.py
 
+Run the test suite from a Docker container
+------------------------------------------
+
+If you cannot (or don't want to) install pytest and its requirements on your computer. You can use the nginx-proxy-tester docker image to run the test suite from a Docker container.
+
+    make test-debian
+
+or if you want to test the alpine flavor:
+
+    make test-alpine
 
 Write a test module
 -------------------

--- a/test/requirements/Dockerfile-nginx-proxy-tester
+++ b/test/requirements/Dockerfile-nginx-proxy-tester
@@ -5,5 +5,32 @@ ENV PYTEST_RUNNING_IN_CONTAINER=1
 COPY python-requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt
 
+# Add Docker's official GPG key
+RUN apt-get update \
+  && apt-get install -y \
+    ca-certificates \
+    curl \
+    gnupg \
+  && install -m 0755 -d /etc/apt/keyrings \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+  && chmod a+r /etc/apt/keyrings/docker.gpg
+
+# Add the Docker repository to Apt sources
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Install docker-ce-cli and docker-compose-plugin requirements for Pytest docker_compose fixture
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    docker-ce-cli \
+    docker-compose-plugin \
+  && apt-get clean \
+  && rm -r /var/lib/apt/lists/*
+
+# Check if docker compose is available
+RUN docker compose version
+
 WORKDIR /test
 ENTRYPOINT ["pytest"]


### PR DESCRIPTION
Follow up of #2343 to make sure Docker Compose v2 is installed in the `nginx-proxy-tester` image.

- Install docker-ce-cli and docker-compose-plugin from [official apt repository instructions](https://docs.docker.com/engine/install/debian/#install-using-the-repository) in the nginx-proxy-tester image.
- Document Docker Compose v2 requirement in tests readme

Just `docker-compose-plugin` or `docker-ce-cli` was not enough. Both seems to be required. 
I went for the the apt install method, so we do not have to track updates or dependencies.