### PR TITLE
build: add the openssl cli back to the alpine image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -14,7 +14,7 @@ ENV NGINX_PROXY_VERSION=${NGINX_PROXY_VERSION} \
    DOCKER_HOST=unix:///tmp/docker.sock
 
 # Install dependencies
-RUN apk add --no-cache --virtual .run-deps bash
+RUN apk add --no-cache --virtual .run-deps bash openssl
 
 # Configure Nginx
 RUN sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf \


### PR DESCRIPTION
The OpenSSL CLI was removed from the alpine image in #2359 because it wasn't a required dependencies, but it was useful to some people (see #2371). Since it's a small size difference, let's add it back.