### PR TITLE
fix: set worker_rlimit_nofile to (worker_connections x 2)

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -17,8 +17,10 @@ ENV NGINX_PROXY_VERSION=${NGINX_PROXY_VERSION} \
 RUN apk add --no-cache --virtual .run-deps bash openssl
 
 # Configure Nginx
-RUN sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf \
-   && mkdir -p '/etc/nginx/dhparam'
+RUN sed -i 's/worker_connections.*;$/worker_connections   10240;/' /etc/nginx/nginx.conf \
+   && sed -i -e '/^\}$/{s//\}\nworker_rlimit_nofile 20480;/;:a' -e '$!N;$!ba' -e '}' /etc/nginx/nginx.conf \
+   && mkdir -p '/etc/nginx/dhparam' \
+   && mkdir -p '/etc/nginx/certs'
 
 # Install Forego + docker-gen
 COPY --from=forego /usr/local/bin/forego /usr/local/bin/forego

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -14,8 +14,10 @@ ENV NGINX_PROXY_VERSION=${NGINX_PROXY_VERSION} \
    DOCKER_HOST=unix:///tmp/docker.sock
 
 # Configure Nginx
-RUN sed -i 's/worker_connections  1024/worker_connections  10240/' /etc/nginx/nginx.conf \
-   && mkdir -p '/etc/nginx/dhparam'
+RUN sed -i 's/worker_connections.*;$/worker_connections  10240;/' /etc/nginx/nginx.conf \
+   && sed -i -e '/^\}$/{s//\}\nworker_rlimit_nofile 20480;/;:a' -e '$!N;$!ba' -e '}' /etc/nginx/nginx.conf \
+   && mkdir -p '/etc/nginx/dhparam' \
+   && mkdir -p '/etc/nginx/certs'
 
 # Install Forego + docker-gen
 COPY --from=forego /usr/local/bin/forego /usr/local/bin/forego


### PR DESCRIPTION
This is an attempted fix for #1780 by setting [worker_rlimit_nofile](https://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile) value to two times the value we use for [worker_connections](https://nginx.org/en/docs/ngx_core_module.html#worker_connections) (10240 x 2 = 20480). [This is what is recommended by nginx as a minimum](https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#insufficient-fds) and it appeared to fix #1780 for @danifr

The hard to decipher regex is used to insert `worker_rlimit_nofile 20480;` to `/etc/nginx/nginx.conf` only once, after the first occurence of the character `}`.