### PR TITLE
tests: non standard port Host header check

### DIFF
--- a/test/test_http_port.py
+++ b/test/test_http_port.py
@@ -6,3 +6,8 @@ def test_web1_http_custom_port(docker_compose, nginxproxy, subdomain):
     r = nginxproxy.get("http://%s.nginx-proxy.tld:8080/port" % subdomain, allow_redirects=False)
     assert r.status_code == 200
     assert "answer from port 81\n" in r.text
+
+def test_nonstandardport_Host_header(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://web.nginx-proxy.tld:8080/headers")
+    assert r.status_code == 200
+    assert "Host: web.nginx-proxy.tld:8080" in r.text

--- a/test/test_ssl/test_https_port.py
+++ b/test/test_ssl/test_https_port.py
@@ -12,3 +12,8 @@ def test_web1_https_is_forwarded(docker_compose, nginxproxy, subdomain):
     r = nginxproxy.get("https://%s.nginx-proxy.tld:8443/port" % subdomain, allow_redirects=False)
     assert r.status_code == 200
     assert "answer from port 81\n" in r.text
+
+def test_nonstandardport_Host_header(docker_compose, nginxproxy):
+    r = nginxproxy.get("https://web.nginx-proxy.tld:8443/headers")
+    assert r.status_code == 200
+    assert "Host: web.nginx-proxy.tld:8443" in r.text


### PR DESCRIPTION
Tests for #2388: Make sure the port number is included in the Host header for non standard ports.