### PR TITLE
build: revert nginx to 1.25.3

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -3,7 +3,7 @@ FROM nginxproxy/docker-gen:0.11.2 AS docker-gen
 FROM nginxproxy/forego:0.18.1 AS forego
 
 # Build the final image
-FROM nginx:1.25.4-alpine
+FROM nginx:1.25.3-alpine
 
 ARG NGINX_PROXY_VERSION
 # Add DOCKER_GEN_VERSION environment variable because 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -3,7 +3,7 @@ FROM nginxproxy/docker-gen:0.11.2-debian AS docker-gen
 FROM nginxproxy/forego:0.18.1-debian AS forego
 
 # Build the final image
-FROM nginx:1.25.4
+FROM nginx:1.25.3
 
 ARG NGINX_PROXY_VERSION
 # Add DOCKER_GEN_VERSION environment variable because 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Test](https://github.com/nginx-proxy/nginx-proxy/actions/workflows/test.yml/badge.svg)](https://github.com/nginx-proxy/nginx-proxy/actions/workflows/test.yml)
 [![GitHub release](https://img.shields.io/github/v/release/nginx-proxy/nginx-proxy)](https://github.com/nginx-proxy/nginx-proxy/releases)
-![nginx 1.25.4](https://img.shields.io/badge/nginx-1.25.4-brightgreen.svg)
+![nginx 1.25.3](https://img.shields.io/badge/nginx-1.25.3-brightgreen.svg)
 [![Docker Image Size](https://img.shields.io/docker/image-size/nginxproxy/nginx-proxy?sort=semver)](https://hub.docker.com/r/nginxproxy/nginx-proxy "Click to view the image on Docker Hub")
 [![Docker stars](https://img.shields.io/docker/stars/nginxproxy/nginx-proxy.svg)](https://hub.docker.com/r/nginxproxy/nginx-proxy "DockerHub")
 [![Docker pulls](https://img.shields.io/docker/pulls/nginxproxy/nginx-proxy.svg)](https://hub.docker.com/r/nginxproxy/nginx-proxy "DockerHub")

--- a/test/certs/create_server_certificate.sh
+++ b/test/certs/create_server_certificate.sh
@@ -24,7 +24,7 @@ fi
 # Create a nginx container (which conveniently provides the `openssl` command)
 ###############################################################################
 
-CONTAINER=$(docker run -d -v $DIR:/work -w /work -e SAN="$ALTERNATE_DOMAINS" nginx:1.25.4)
+CONTAINER=$(docker run -d -v $DIR:/work -w /work -e SAN="$ALTERNATE_DOMAINS" nginx:1.25.3)
 # Configure openssl
 docker exec $CONTAINER bash -c '
 	mkdir -p /ca/{certs,crl,private,newcerts} 2>/dev/null


### PR DESCRIPTION
[nginx 1.25.4-alpine image seems to be inconsistently available for some archs](https://github.com/nginxinc/docker-nginx/issues/866), which result in CI build failure.

1.5.1 release will be removed until this is fixed.