### PR TITLE
correctly handle redirect logic for path-base routing

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -276,6 +276,9 @@
         grpc_pass {{ trim $proto }}://{{ trim $upstream }};
         {{- else }}
         proxy_pass {{ trim $proto }}://{{ trim $upstream }}{{ trim $dest }};
+            {{- if not (eq .Path "/") }}
+        proxy_redirect ~^/(.*)$ {{ trimSuffix `/` .Path }}/$1;
+            {{- end }}
         set $upstream_keepalive {{ if ne $keepalive "disabled" }}true{{ else }}false{{ end }};
         {{- end }}
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -276,8 +276,8 @@
         grpc_pass {{ trim $proto }}://{{ trim $upstream }};
         {{- else }}
         proxy_pass {{ trim $proto }}://{{ trim $upstream }}{{ trim $dest }};
-            {{- if not (eq .Path "/") }}
-        proxy_redirect ~^/(.*)$ {{ trimSuffix `/` .Path }}/$1;
+            {{- if (hasPrefix "/" $dest) }}
+        proxy_redirect ~^{{ $dest }}(.*)$ {{ .Path }}$1;
             {{- end }}
         set $upstream_keepalive {{ if ne $keepalive "disabled" }}true{{ else }}false{{ end }};
         {{- end }}


### PR DESCRIPTION
Now path-base routing can not correctly handle redirect logic for path-base routing
The example is as below, this is a demo docker compose file to reproduce the issue.
```docker-compose.yaml
version: '3.8'

services:
  nginx-proxy:
    image: nginxproxy/nginx-proxy
    restart: always
    environment:
      - ENABLE_IPV6=true
      - DEFAULT_HOST=localhost
    volumes:
      - /var/run/docker.sock:/tmp/docker.sock:ro
    ports:
      - 80:80
      - 443:443
    networks:
      - nat-bridge

  jellyfin:
    image: linuxserver/jellyfin
    restart: always
    environment:
      - VIRTUAL_HOST=localhost
      - VIRTUAL_PORT=8096
      - VIRTUAL_PATH=/jellyfin/
      - VIRTUAL_DEST=/
    ports:
      - 8096:8096
    networks:
      - nat-bridge
networks:
  nat-bridge:
```

start it and access http://localhost/jellyfin/ from browser, and you can see the issue as below:
The redirect response do not go jellyfin app.
![image](https://github.com/nginx-proxy/nginx-proxy/assets/17874954/c3b98a31-97b4-4f34-834f-be3530fe7eb7)
