### PR TITLE
feat: custom default error page

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -22,7 +22,8 @@ RUN echo -e "\ninclude /etc/nginx/toplevel.conf.d/*.conf;" >> /etc/nginx/nginx.c
    && sed -i -e '/^\}$/{s//\}\nworker_rlimit_nofile 20480;/;:a' -e '$!N;$!ba' -e '}' /etc/nginx/nginx.conf \
    && mkdir -p '/etc/nginx/toplevel.conf.d' \
    && mkdir -p '/etc/nginx/dhparam' \
-   && mkdir -p '/etc/nginx/certs'
+   && mkdir -p '/etc/nginx/certs' \
+   && mkdir -p '/usr/share/nginx/html/errors'
 
 # Install Forego + docker-gen
 COPY --from=forego /usr/local/bin/forego /usr/local/bin/forego

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -19,7 +19,8 @@ RUN echo "\ninclude /etc/nginx/toplevel.conf.d/*.conf;" >> /etc/nginx/nginx.conf
    && sed -i -e '/^\}$/{s//\}\nworker_rlimit_nofile 20480;/;:a' -e '$!N;$!ba' -e '}' /etc/nginx/nginx.conf \
    && mkdir -p '/etc/nginx/toplevel.conf.d' \
    && mkdir -p '/etc/nginx/dhparam' \
-   && mkdir -p '/etc/nginx/certs'
+   && mkdir -p '/etc/nginx/certs' \
+   && mkdir -p '/usr/share/nginx/html/errors'
 
 # Install Forego + docker-gen
 COPY --from=forego /usr/local/bin/forego /usr/local/bin/forego

--- a/docs/README.md
+++ b/docs/README.md
@@ -799,7 +799,7 @@ Per virtual-host `servers_tokens` directive can be configured by passing appropr
 
 ### Custom error page
 
-To override the default (nginx provided) error page displayed on 50x errors, mount your custom HTML error page inside the container at `/usr/share/nginx/html/errors/50x.html`:
+To override the default error page displayed on 50x errors, mount your custom HTML error page inside the container at `/usr/share/nginx/html/errors/50x.html`:
 
 ```console
 docker run --detach \

--- a/docs/README.md
+++ b/docs/README.md
@@ -797,6 +797,21 @@ location / {
 
 Per virtual-host `servers_tokens` directive can be configured by passing appropriate value to the `SERVER_TOKENS` environment variable. Please see the [nginx http_core module configuration](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens) for more details.
 
+### Custom error page
+
+To override the default (nginx provided) error page displayed on 50x errors, mount your custom HTML error page inside the container at `/usr/share/nginx/html/50x.html`:
+
+```console
+docker run --detach \
+    --name nginx-proxy \
+    --publish 80:80 \
+    --volume /var/run/docker.sock:/tmp/docker.sock:ro \
+    --volume /path/to/error.html:/usr/share/nginx/html/50x.html:ro \
+    nginxproxy/nginx-proxy:1.5
+```
+
+Note that this will not replace your own services error pages.
+
 ⬆️ [back to table of contents](#table-of-contents)
 
 ## TCP and UDP stream

--- a/docs/README.md
+++ b/docs/README.md
@@ -799,14 +799,14 @@ Per virtual-host `servers_tokens` directive can be configured by passing appropr
 
 ### Custom error page
 
-To override the default (nginx provided) error page displayed on 50x errors, mount your custom HTML error page inside the container at `/usr/share/nginx/html/50x.html`:
+To override the default (nginx provided) error page displayed on 50x errors, mount your custom HTML error page inside the container at `/usr/share/nginx/html/errors/50x.html`:
 
 ```console
 docker run --detach \
     --name nginx-proxy \
     --publish 80:80 \
     --volume /var/run/docker.sock:/tmp/docker.sock:ro \
-    --volume /path/to/error.html:/usr/share/nginx/html/50x.html:ro \
+    --volume /path/to/error.html:/usr/share/nginx/html/errors/50x.html:ro \
     nginxproxy/nginx-proxy:1.5
 ```
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -703,10 +703,10 @@ server {
     }
         {{- end }}
 
-        {{- if (exists "/usr/share/nginx/html/50x.html") }}
+        {{- if (exists "/usr/share/nginx/html/errors/50x.html") }}
     error_page 500 502 503 504 /50x.html;
     location /50x.html {
-        root /usr/share/nginx/html;
+        root /usr/share/nginx/html/errors;
         internal;
     }
         {{- end }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -710,7 +710,7 @@ server {
         internal;
     }
         {{- end }}
-    location / {
+    location ^~ / {
         return 503;
     }
 }

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -702,7 +702,17 @@ server {
         return 444;
     }
         {{- end }}
-    return 503;
+
+        {{- if (exists "/usr/share/nginx/html/50x.html") }}
+    error_page 500 502 503 504 /50x.html;
+    location /50x.html {
+        root /usr/share/nginx/html;
+        internal;
+    }
+        {{- end }}
+    location / {
+        return 503;
+    }
 }
     {{- end }}
 {{- end }}

--- a/test/test_custom-error-page/50x.html
+++ b/test/test_custom-error-page/50x.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Maintenance</title>
+    <style>
+      html {
+        color-scheme: light dark;
+      }
+      body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Damn, there's some maintenance in progress.</h1>
+    <p>
+      Our apologies for this temporary inconvenience. Regular service
+      performance will be re-established shortly.
+    </p>
+  </body>
+</html>

--- a/test/test_custom-error-page/test_custom-error-page.py
+++ b/test/test_custom-error-page/test_custom-error-page.py
@@ -1,0 +1,8 @@
+import pytest
+import re
+
+
+def test_custom_error_page(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://unknown.nginx-proxy.tld")
+    assert r.status_code == 503
+    assert re.search(r"Damn, there's some maintenance in progress.", r.text)

--- a/test/test_custom-error-page/test_custom-error-page.yml
+++ b/test/test_custom-error-page/test_custom-error-page.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+services:
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./50x.html:/usr/share/nginx/html/50x.html:ro

--- a/test/test_custom-error-page/test_custom-error-page.yml
+++ b/test/test_custom-error-page/test_custom-error-page.yml
@@ -5,4 +5,4 @@ services:
     image: nginxproxy/nginx-proxy:test
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ./50x.html:/usr/share/nginx/html/50x.html:ro
+      - ./50x.html:/usr/share/nginx/html/errors/50x.html:ro


### PR DESCRIPTION
This PR restore the default error page provided by the nginx container and allows to customise it by mounting another HTML file in its place.

Solve #1325 