### PR TITLE
fix: tests webserver syntaxwarning

### DIFF
--- a/test/requirements/web/webserver.py
+++ b/test/requirements/web/webserver.py
@@ -14,8 +14,8 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             response_body += self.headers.as_string()
         elif self.path == "/port":
             response_body += f"answer from port {PORT}\n"
-        elif re.match("/status/(\d+)", self.path):
-            result = re.match("/status/(\d+)", self.path)
+        elif re.match(r"/status/(\d+)", self.path):
+            result = re.match(r"/status/(\d+)", self.path)
             response_code = int(result.group(1))
             response_body += f"answer with response code {response_code}\n"
         elif self.path == "/":


### PR DESCRIPTION
> Changed in Python version 3.12: Unrecognized escape sequences produce a SyntaxWarning. In a future Python version they will be eventually a SyntaxError.
[2.4.1.1. Escape sequences](https://docs.python.org/3/reference/lexical_analysis.html#index-23)

Change to raw string literal to fix:
```
/webserver.py:17: SyntaxWarning: invalid escape sequence '\d'
  elif re.match("/status/(\d+)", self.path):
/webserver.py:18: SyntaxWarning: invalid escape sequence '\d'
  result = re.match("/status/(\d+)", self.path)
```