### PR TITLE
test: use python alpine variant as base for web image

### DIFF
--- a/test/requirements/web/Dockerfile
+++ b/test/requirements/web/Dockerfile
@@ -1,6 +1,7 @@
 # Docker Image running one (or multiple) webservers listening on all given ports from WEB_PORTS environment variable
 
-FROM python:3
+FROM python:3-alpine
+RUN apk add --no-cache bash
 COPY ./webserver.py /
 COPY ./entrypoint.sh /
 WORKDIR /opt

--- a/test/requirements/web/entrypoint.sh
+++ b/test/requirements/web/entrypoint.sh
@@ -5,11 +5,11 @@ trap '[ ${#PIDS[@]} -gt 0 ] && kill -TERM ${PIDS[@]}' TERM
 declare -a PIDS
 
 for port in $WEB_PORTS; do
-	echo starting a web server listening on port $port;
-	/webserver.py $port &
+	echo starting a web server listening on port "$port";
+	/webserver.py "$port" &
 	PIDS+=($!)
 done
 
-wait ${PIDS[@]}
+wait "${PIDS[@]}"
 trap - TERM
-wait ${PIDS[@]}
+wait "${PIDS[@]}"


### PR DESCRIPTION
This PR use the alpine variant of the python Docker image as a base for the `web` test helper image, as we don't need the significantly larger debian variant.