### PR TITLE
fix: enforce nohhtp on missing cert as well

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -642,7 +642,7 @@ proxy_set_header Proxy "";
     {{- $default_https_exists := false }}
     {{- $http3_enabled := false }}
     {{- range $vhost := $globals.vhosts }}
-        {{- $http := or (ne $vhost.https_method "nohttp") (not $vhost.cert_ok) }}
+        {{- $http := ne $vhost.https_method "nohttp" }}
         {{- $https := ne $vhost.https_method "nohttps" }}
         {{- $http_exists = or $http_exists $http }}
         {{- $https_exists = or $https_exists $https }}
@@ -715,7 +715,7 @@ server {
         {{ template "upstream" (dict "globals" $globals "Path" $path "VPath" $vpath) }}
     {{- end }}
 
-    {{- if and $vhost.cert_ok (eq $vhost.https_method "redirect") }}
+    {{- if (eq $vhost.https_method "redirect") }}
 server {
     server_name {{ $hostname }};
         {{- if $vhost.server_tokens }}
@@ -756,7 +756,7 @@ server {
     {{- if $vhost.http2_enabled }}
     http2 on;
     {{- end }}
-    {{- if or (eq $vhost.https_method "nohttps") (not $vhost.cert_ok) (eq $vhost.https_method "noredirect") }}
+    {{- if or (eq $vhost.https_method "nohttps") (eq $vhost.https_method "noredirect") }}
     listen {{ $globals.external_http_port }} {{ $default_server }};
         {{- if $globals.enable_ipv6 }}
     listen [::]:{{ $globals.external_http_port }} {{ $default_server }};

--- a/test/test_fallback.py
+++ b/test/test_fallback.py
@@ -44,7 +44,7 @@ CONNECTION_REFUSED_RE = re.compile("Connection refused")
     ("withdefault.yml", "https://https-only.nginx-proxy.test/", 200, None),
     ("withdefault.yml", "http://http-only.nginx-proxy.test/", 200, None),
     ("withdefault.yml", "https://http-only.nginx-proxy.test/", 503, None),
-    ("withdefault.yml", "http://missing-cert.nginx-proxy.test/", 200, None),
+    ("withdefault.yml", "http://missing-cert.nginx-proxy.test/", 301, None),
     ("withdefault.yml", "https://missing-cert.nginx-proxy.test/", 500, None),
     ("withdefault.yml", "http://unknown.nginx-proxy.test/", 503, None),
     ("withdefault.yml", "https://unknown.nginx-proxy.test/", 503, None),
@@ -55,7 +55,7 @@ CONNECTION_REFUSED_RE = re.compile("Connection refused")
     ("nodefault.yml", "https://https-only.nginx-proxy.test/", 200, None),
     ("nodefault.yml", "http://http-only.nginx-proxy.test/", 200, None),
     ("nodefault.yml", "https://http-only.nginx-proxy.test/", None, INTERNAL_ERR_RE),
-    ("nodefault.yml", "http://missing-cert.nginx-proxy.test/", 200, None),
+    ("nodefault.yml", "http://missing-cert.nginx-proxy.test/", 301, None),
     ("nodefault.yml", "https://missing-cert.nginx-proxy.test/", None, INTERNAL_ERR_RE),
     ("nodefault.yml", "http://unknown.nginx-proxy.test/", 503, None),
     ("nodefault.yml", "https://unknown.nginx-proxy.test/", None, INTERNAL_ERR_RE),
@@ -69,11 +69,11 @@ CONNECTION_REFUSED_RE = re.compile("Connection refused")
     ("nohttp-on-app.yml", "https://https-only.nginx-proxy.test/", 200, None),
     ("nohttp-on-app.yml", "http://unknown.nginx-proxy.test/", 503, None),
     ("nohttp-on-app.yml", "https://unknown.nginx-proxy.test/", 503, None),
-    # Same as nohttp.yml, except there is a vhost with a missing cert.  This causes its
-    # HTTPS_METHOD=nohttp setting to effectively become HTTPS_METHOD=noredirect.
+    # Same as nohttp.yml, except there is a vhost with a missing cert.
+    # nohttp should be enforced in this case as well.
     ("nohttp-with-missing-cert.yml", "http://https-only.nginx-proxy.test/", 503, None),
     ("nohttp-with-missing-cert.yml", "https://https-only.nginx-proxy.test/", 200, None),
-    ("nohttp-with-missing-cert.yml", "http://missing-cert.nginx-proxy.test/", 200, None),
+    ("nohttp-with-missing-cert.yml", "http://missing-cert.nginx-proxy.test/", 503, None),
     ("nohttp-with-missing-cert.yml", "https://missing-cert.nginx-proxy.test/", 500, None),
     ("nohttp-with-missing-cert.yml", "http://unknown.nginx-proxy.test/", 503, None),
     ("nohttp-with-missing-cert.yml", "https://unknown.nginx-proxy.test/", 503, None),


### PR DESCRIPTION
There is no reason to silently switch from nohhtp to noredirect on missing cert.