### PR TITLE
fix: hardcode requests package version to 2.31.0

### DIFF
--- a/test/requirements/python-requirements.txt
+++ b/test/requirements/python-requirements.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 docker==7.0.0
 pytest==8.2.1
-requests==2.32.1
+requests==2.31.0


### PR DESCRIPTION
requests version >= `2.32.0` is currently incompatible with docker-py `7.0.0`, see https://github.com/docker/docker-py/issues/3256 and https://github.com/psf/requests/issues/6707

This reverts commit 1c1f8e8700eaba62af96e63ef885b6efbe90f069.