### PR TITLE
Compose update, documentation format and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See [Automated Nginx Reverse Proxy for Docker](http://jasonwilder.com/blog/2014/
 
 To run it:
 
-```console
+```sh
 docker run --detach \
     --name nginx-proxy \
     --publish 80:80 \
@@ -23,7 +23,7 @@ docker run --detach \
 
 Then start any containers (here an nginx container) you want proxied with an env var `VIRTUAL_HOST=subdomain.yourdomain.com`
 
-```console
+```sh
 docker run --detach \
     --name your-proxied-app \
     --env VIRTUAL_HOST=foo.bar.com \
@@ -47,7 +47,7 @@ The nginx-proxy images are available in two flavors.
 
 This image is based on the nginx:mainline image, itself based on the debian slim image.
 
-```console
+```sh
 docker pull nginxproxy/nginx-proxy:1.6
 ```
 
@@ -55,7 +55,7 @@ docker pull nginxproxy/nginx-proxy:1.6
 
 This image is based on the nginx:alpine image.
 
-```console
+```sh
 docker pull nginxproxy/nginx-proxy:1.6-alpine
 ```
 

--- a/compose.separate.yml
+++ b/compose.separate.yml
@@ -1,11 +1,9 @@
-version: "2"
-
 services:
   nginx:
     image: nginx
     container_name: nginx
     ports:
-      - "80:80"
+      - 80:80
     volumes:
       - /etc/nginx/conf.d
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,11 +1,10 @@
-version: "2"
-
 services:
   nginx-proxy:
     image: nginxproxy/nginx-proxy
     container_name: nginx-proxy
     ports:
-      - "80:80"
+      - 80:80
+      - 443:443
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -310,7 +310,7 @@ services:
       VIRTUAL_HOST: myapp.example
       VIRTUAL_PORT: 8000
     labels:
-      com.github.nginx-proxy.nginx-proxy.loadbalance: hash $$remote_addr
+      com.github.nginx-proxy.nginx-proxy.loadbalance: hash $$remote_addr;
     deploy:
       replicas: 4
 ```
@@ -350,7 +350,7 @@ You'll need apache2-utils on the machine where you plan to create the htpasswd f
 
 The default nginx access log format is
 
-```
+```log
 $host $remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$upstream_addr"
 ```
 
@@ -609,7 +609,7 @@ If the default certificate is also missing, nginx-proxy will configure nginx to 
 
 You can activate the IPv6 support for the nginx-proxy container by passing the value `true` to the `ENABLE_IPV6` environment variable:
 
-```console
+```sh
 docker run -d -p 80:80 -e ENABLE_IPV6=true -v /var/run/docker.sock:/tmp/docker.sock:ro nginxproxy/nginx-proxy
 ```
 
@@ -725,7 +725,7 @@ RUN { \
 
 Or it can be done by mounting in your custom configuration in your `docker run` command:
 
-```console
+```sh
 docker run -d -p 80:80 -p 443:443 -v /path/to/my_proxy.conf:/etc/nginx/conf.d/my_proxy.conf:ro -v /var/run/docker.sock:/tmp/docker.sock:ro nginxproxy/nginx-proxy
 ```
 
@@ -737,7 +737,7 @@ In order to allow virtual hosts to be dynamically configured as backends are add
 
 For example, if you have a virtual host named `app.example.com`, you could provide a custom configuration for that host as follows:
 
-```console
+```sh
 docker run -d -p 80:80 -p 443:443 -v /path/to/vhost.d:/etc/nginx/vhost.d:ro -v /var/run/docker.sock:/tmp/docker.sock:ro nginxproxy/nginx-proxy
 { echo 'server_tokens off;'; echo 'client_max_body_size 100m;'; } > /path/to/vhost.d/app.example.com
 ```
@@ -795,7 +795,7 @@ When an override file exists, the `location` block that is normally created by `
 
 You are responsible for providing a suitable `location` block in your override file as required for your service. By default, `nginx-proxy` uses the `VIRTUAL_HOST` name as the upstream name for your application's Docker container; see [here](#unhashed-vs-sha1-upstream-names) for details. As an example, if your container has a `VIRTUAL_HOST` value of `app.example.com`, then to override the location block for `/` you would create a file named `/etc/nginx/vhost.d/app.example.com_location_override` that contains something like this:
 
-```
+```Nginx
 location / {
     proxy_pass http://app.example.com;
 }
@@ -825,7 +825,7 @@ Note that this will not replace your own services error pages.
 
 If you want to proxy non-HTTP traffic, you can use nginx's stream module. Write a configuration file and mount it inside `/etc/nginx/toplevel.conf.d`.
 
-```nginx
+```Nginx
 # stream.conf
 stream {
     upstream stream_backend {


### PR DESCRIPTION
# Docker Compose
docker-compose.yml updated to compose.yml standard
docker-compose-separate-containers.yml renamed to compose.separate.yml and updated to standard

version property deprecated (Used for legacy docker-compose)

# readme
most \`\`\`console tags changed to \`\`\`sh for better readability:

```console
mkdir -p example
```
```sh
mkdir -p example
```

Some commands were slightly incorrect

And since docs/readme.md used shortened flags for command options most of the time, standardized for all commands there