### PR TITLE
Limit exposed ports in template to 10

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -125,7 +125,7 @@
      */}}
 {{- define "container_port" }}
     {{- /* If only 1 port exposed, use that as a default, else 80. */}}
-    #     exposed ports:{{ range sortObjectsByKeysAsc $.container.Addresses "Port" }} {{ .Port }}/{{ .Proto }}{{ else }} (none){{ end }}
+    #     exposed ports:{{ $maxPorts := 10 }}{{ $count := 0 }}{{ range sortObjectsByKeysAsc $.container.Addresses "Port" }}{{ if lt $count $maxPorts }} {{ .Port }}/{{ .Proto }}{{ $count = add $count 1 }}{{ end }}{{ else }} (none){{ end }}
     {{- $default_port := when (eq (len $.container.Addresses) 1) (first $.container.Addresses).Port "80" }}
     #     default port: {{ $default_port }}
     {{- $port := when (eq $.port "default") $default_port (when (eq $.port "legacy") (or $.container.Env.VIRTUAL_PORT $default_port) $.port) }}
@@ -474,7 +474,7 @@ proxy_set_header Proxy "";
     {{- range $hostname, $vhost := $parsedVhosts }}
         {{- $vhost_data := when (hasKey $globals.vhosts $hostname) (get $globals.vhosts $hostname) (dict) }}
         {{- $paths := coalesce $vhost_data.paths (dict) }}
-        
+
         {{- if (empty $vhost) }}
             {{ $vhost = dict "/" (dict) }}
         {{- end }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -125,7 +125,7 @@
      */}}
 {{- define "container_port" }}
     {{- /* If only 1 port exposed, use that as a default, else 80. */}}
-    #     exposed ports:{{ $maxPorts := 10 }}{{ $count := 0 }}{{ range sortObjectsByKeysAsc $.container.Addresses "Port" }}{{ if lt $count $maxPorts }} {{ .Port }}/{{ .Proto }}{{ $count = add $count 1 }}{{ end }}{{ else }} (none){{ end }}
+    #     exposed ports:{{ range $index, $address := (sortObjectsByKeysAsc $.container.Addresses "Port") }}{{ if lt $index 10 }} {{ $address.Port }}/{{ $address.Proto }}{{ end }}{{ else }} (none){{ end }}
     {{- $default_port := when (eq (len $.container.Addresses) 1) (first $.container.Addresses).Port "80" }}
     #     default port: {{ $default_port }}
     {{- $port := when (eq $.port "default") $default_port (when (eq $.port "legacy") (or $.container.Env.VIRTUAL_PORT $default_port) $.port) }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -125,7 +125,7 @@
      */}}
 {{- define "container_port" }}
     {{- /* If only 1 port exposed, use that as a default, else 80. */}}
-    #     exposed ports:{{ range $index, $address := (sortObjectsByKeysAsc $.container.Addresses "Port") }}{{ if lt $index 10 }} {{ $address.Port }}/{{ $address.Proto }}{{ end }}{{ else }} (none){{ end }}
+    #     exposed ports (first ten):{{ range $index, $address := (sortObjectsByKeysAsc $.container.Addresses "Port") }}{{ if lt $index 10 }} {{ $address.Port }}/{{ $address.Proto }}{{ end }}{{ else }} (none){{ end }}
     {{- $default_port := when (eq (len $.container.Addresses) 1) (first $.container.Addresses).Port "80" }}
     #     default port: {{ $default_port }}
     {{- $port := when (eq $.port "default") $default_port (when (eq $.port "legacy") (or $.container.Env.VIRTUAL_PORT $default_port) $.port) }}


### PR DESCRIPTION
This fixes the problem described in [this issue](https://github.com/nginx-proxy/nginx-proxy/issues/2492) where containers that expose a large number of ports will cause the template to render a line exceeding the max line length of Nginx.