### PR TITLE
fix: use fastcgi.conf on alpine and fastcgi_params on debien

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -264,8 +264,14 @@
         include uwsgi_params;
         uwsgi_pass {{ trim $proto }}://{{ trim $upstream }};
         {{- else if eq $proto "fastcgi" }}
-        root {{ trim .VhostRoot }};
+            {{- if (exists "/etc/nginx/fastcgi.conf") }}
         include fastcgi.conf;
+            {{- else if (exists "/etc/nginx/fastcgi_params") }}
+        include fastcgi_params;
+            {{- else }}
+        # neither /etc/nginx/fastcgi.conf nor /etc/nginx/fastcgi_params found, fastcgi won't work
+            {{- end }}
+        root {{ trim .VhostRoot }};
         fastcgi_pass {{ trim $upstream }};
             {{- if ne $keepalive "disabled" }}
         fastcgi_keep_conn on;


### PR DESCRIPTION
This should fix #2496 by using the correct file on Debian and Alpine.

@fauzanelka could you test the [`nginxproxy/nginx-proxy:2496`](https://hub.docker.com/layers/nginxproxy/nginx-proxy/2496/images/sha256-14feb8587e866aeea288047794606718fb131caa10a254626215323bbb1ee7ce?context=repo) image ?