### PR TITLE
build: bump nginx 1.27.0 to 1.27.1

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -3,7 +3,7 @@ FROM docker.io/nginxproxy/docker-gen:0.14.2 AS docker-gen
 FROM docker.io/nginxproxy/forego:0.18.2 AS forego
 
 # Build the final image
-FROM docker.io/library/nginx:1.27.0-alpine
+FROM docker.io/library/nginx:1.27.1-alpine
 
 ARG NGINX_PROXY_VERSION
 # Add DOCKER_GEN_VERSION environment variable because 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -3,7 +3,7 @@ FROM docker.io/nginxproxy/docker-gen:0.14.2-debian AS docker-gen
 FROM docker.io/nginxproxy/forego:0.18.2-debian AS forego
 
 # Build the final image
-FROM docker.io/library/nginx:1.27.0
+FROM docker.io/library/nginx:1.27.1
 
 ARG NGINX_PROXY_VERSION
 # Add DOCKER_GEN_VERSION environment variable because 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Test](https://github.com/nginx-proxy/nginx-proxy/actions/workflows/test.yml/badge.svg)](https://github.com/nginx-proxy/nginx-proxy/actions/workflows/test.yml)
 [![GitHub release](https://img.shields.io/github/v/release/nginx-proxy/nginx-proxy)](https://github.com/nginx-proxy/nginx-proxy/releases)
-![nginx 1.27.0](https://img.shields.io/badge/nginx-1.27.0-brightgreen.svg)
+[![nginx 1.27.1](https://img.shields.io/badge/nginx-1.27.1-brightgreen.svg?logo=nginx)](https://nginx.org)
 [![Docker Image Size](https://img.shields.io/docker/image-size/nginxproxy/nginx-proxy?sort=semver)](https://hub.docker.com/r/nginxproxy/nginx-proxy "Click to view the image on Docker Hub")
 [![Docker stars](https://img.shields.io/docker/stars/nginxproxy/nginx-proxy.svg)](https://hub.docker.com/r/nginxproxy/nginx-proxy "DockerHub")
 [![Docker pulls](https://img.shields.io/docker/pulls/nginxproxy/nginx-proxy.svg)](https://hub.docker.com/r/nginxproxy/nginx-proxy "DockerHub")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Test](https://github.com/nginx-proxy/nginx-proxy/actions/workflows/test.yml/badge.svg)](https://github.com/nginx-proxy/nginx-proxy/actions/workflows/test.yml)
 [![GitHub release](https://img.shields.io/github/v/release/nginx-proxy/nginx-proxy)](https://github.com/nginx-proxy/nginx-proxy/releases)
-[![nginx 1.27.1](https://img.shields.io/badge/nginx-1.27.1-brightgreen.svg?logo=nginx)](https://nginx.org)
+[![nginx 1.27.1](https://img.shields.io/badge/nginx-1.27.1-brightgreen.svg?logo=nginx)](https://nginx.org/en/CHANGES)
 [![Docker Image Size](https://img.shields.io/docker/image-size/nginxproxy/nginx-proxy?sort=semver)](https://hub.docker.com/r/nginxproxy/nginx-proxy "Click to view the image on Docker Hub")
 [![Docker stars](https://img.shields.io/docker/stars/nginxproxy/nginx-proxy.svg)](https://hub.docker.com/r/nginxproxy/nginx-proxy "DockerHub")
 [![Docker pulls](https://img.shields.io/docker/pulls/nginxproxy/nginx-proxy.svg)](https://hub.docker.com/r/nginxproxy/nginx-proxy "DockerHub")

--- a/test/certs/create_server_certificate.sh
+++ b/test/certs/create_server_certificate.sh
@@ -24,7 +24,7 @@ fi
 # Create a nginx container (which conveniently provides the `openssl` command)
 ###############################################################################
 
-CONTAINER=$(docker run -d -v $DIR:/work -w /work -e SAN="$ALTERNATE_DOMAINS" nginx:1.27.0)
+CONTAINER=$(docker run -d -v $DIR:/work -w /work -e SAN="$ALTERNATE_DOMAINS" nginx:1.27.1)
 # Configure openssl
 docker exec $CONTAINER bash -c '
 	mkdir -p /ca/{certs,crl,private,newcerts} 2>/dev/null


### PR DESCRIPTION
Normally Dependabot will trigger this but there is an issue: https://github.com/dependabot/dependabot-core/issues/10452 the nginx 1.27.1 image is being detected as pre-release.

I waited 2 weeks but there seems no progress in that issue so I decided to create this PR.

    Changes with nginx 1.27.1                                        14 Aug 2024

    *) Security: processing of a specially crafted mp4 file by the
       ngx_http_mp4_module might cause a worker process crash
       (CVE-2024-7347).
       Thanks to Nils Bars.

    *) Change: now the stream module handler is not mandatory.

    *) Bugfix: new HTTP/2 connections might ignore graceful shutdown of old
       worker processes.
       Thanks to Kasei Wang.

    *) Bugfixes in HTTP/3.
