### PR TITLE
fix: do not render regexp hostname in debug endpoint response

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -380,7 +380,8 @@ upstream {{ $vpath.upstream }} {
     {{- end }}
     
     {{- $debug_vhost := deepCopy .VHost }}
-    {{- $_ := set $debug_vhost "hostname" .Hostname }}
+    {{- /* If it's a regexp, do not render the Hostname to the response to avoid rendering config breaking characters */}}
+    {{- $_ := set $debug_vhost "hostname" (.VHost.is_regexp | ternary "Hostname is a regexp and unsafe to include in the debug response." .Hostname) }}
     {{- $_ := set $debug_vhost "paths" $debug_paths }}
 
     {{- $debug_response := dict

--- a/test/test_debug_endpoint/test_global.py
+++ b/test/test_debug_endpoint/test_global.py
@@ -19,7 +19,7 @@ def test_debug_endpoint_response_contains_expected_values(docker_compose, nginxp
     assert jsonResponse["vhost"]["enable_debug_endpoint"] == True
 
 
-def test_debug_endpoint_pahts_stripped_if_response_too_long(docker_compose, nginxproxy):   
+def test_debug_endpoint_paths_stripped_if_response_too_long(docker_compose, nginxproxy):   
     r = nginxproxy.get("http://stripped.debug.nginx-proxy.example/nginx-proxy-debug")
     assert r.status_code == 200
     try:
@@ -29,6 +29,16 @@ def test_debug_endpoint_pahts_stripped_if_response_too_long(docker_compose, ngin
     if "paths" in jsonResponse["vhost"]:
         pytest.fail("Expected paths to be stripped from debug endpoint response", pytrace=False)
     assert jsonResponse["warning"] == "Virtual paths configuration for this hostname is too large and has been stripped from response."
+
+
+def test_debug_endpoint_hostname_replaced_by_warning_if_regexp(docker_compose, nginxproxy):   
+    r = nginxproxy.get("http://regexp.foo.debug.nginx-proxy.example/nginx-proxy-debug")
+    assert r.status_code == 200
+    try:
+        jsonResponse = json.loads(r.text)
+    except ValueError as err:
+        pytest.fail("Failed to parse debug endpoint response as JSON: %s" % err, pytrace=False)
+    assert jsonResponse["vhost"]["hostname"] == "Hostname is a regexp and unsafe to include in the debug response."
 
 
 def test_debug_endpoint_is_disabled_per_container(docker_compose, nginxproxy):

--- a/test/test_debug_endpoint/test_global.yml
+++ b/test/test_debug_endpoint/test_global.yml
@@ -42,6 +42,14 @@ services:
           "/18":
           "/19":
           "/20":
+  
+  debug_regexp:
+    image: web
+    expose:
+      - "84"
+    environment:
+      WEB_PORTS: 84
+      VIRTUAL_HOST: ~^regexp.*\.debug.nginx-proxy.example
 
   debug_disabled:
     image: web


### PR DESCRIPTION
Solve bug mentioned by @SchoNie in https://github.com/nginx-proxy/nginx-proxy/pull/2525#issuecomment-2455658395