### PR TITLE
test: add test for DISABLE_ACCESS_LOGS

### DIFF
--- a/test/test_logs/test_log_disabled.py
+++ b/test/test_logs/test_log_disabled.py
@@ -1,0 +1,11 @@
+import pytest
+
+def test_log_disabled(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://nginx-proxy.test/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 81\n"
+    sut_container = docker_compose.containers.get("sut")
+    docker_logs = sut_container.logs(stdout=True, stderr=True, stream=False, follow=False)
+    docker_logs = docker_logs.decode("utf-8").splitlines()
+    docker_logs = [line for line in docker_logs if "GET /port" in line]
+    assert len(docker_logs) == 0

--- a/test/test_logs/test_log_disabled.yml
+++ b/test/test_logs/test_log_disabled.yml
@@ -1,0 +1,18 @@
+version: "2"
+
+services:
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: 81
+      VIRTUAL_HOST: nginx-proxy.test
+
+  sut:
+    container_name: sut
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    environment:
+      DISABLE_ACCESS_LOGS: true


### PR DESCRIPTION
Test to verify `DISABLE_ACCESS_LOGS` environment variable [disables](https://github.com/nginx-proxy/nginx-proxy/tree/main/docs#disable-access-logs) access logs.