### PR TITLE
feat: enable keepalive by default

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -317,11 +317,7 @@ services:
 ```
 
 ### Upstream Server HTTP Keep-Alive Support
-
-> **Warning**
-> This feature is experimental. The behavior may change (or the feature may be removed entirely) without warning in a future release, even if the release is not a new major version. If you use this feature, or if you would like to use this feature but you require changes to it first, please [provide feedback in #2194](https://github.com/nginx-proxy/nginx-proxy/discussions/2194). Once we have collected enough feedback we will promote this feature to officially supported.
-
-To enable HTTP keep-alive between `nginx-proxy` and backend server(s), set the `com.github.nginx-proxy.nginx-proxy.keepalive` label on the server's container either to `auto` or to the desired maximum number of idle connections. The `auto` setting will dynamically set the maximum number of idle connections to twice the number of servers listed in the corresponding `upstream{}` block, [per nginx recommendation](https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#no-keepalives).
+By default `nginx-proxy` will enable HTTP keep-alive between itself and backend server(s) and set the maximum number of idle connections to twice the number of servers listed in the corresponding `upstream{}` block, [per nginx recommendation](https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#no-keepalives). To manually set the maximum number of idle connections or disable HTTP keep-alive entirely, use the `com.github.nginx-proxy.nginx-proxy.keepalive` label on the server's container (setting it to `disabled` will disable HTTP keep-alive).
 
 See the [nginx keepalive documentation](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive) and the [Docker label documentation](https://docs.docker.com/config/labels-custom-metadata/) for details.
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -655,7 +655,7 @@ proxy_set_header Proxy "";
         {{- $network_tag := groupByKeys $vpath_containers "Env.NETWORK_ACCESS" | first | default "external" }}
 
         {{- $loadbalance := groupByLabel $vpath_containers "com.github.nginx-proxy.nginx-proxy.loadbalance" | keys | first }}
-        {{- $keepalive := groupByLabel $vpath_containers "com.github.nginx-proxy.nginx-proxy.keepalive" | keys | first | default "disabled" }}
+        {{- $keepalive := groupByLabel $vpath_containers "com.github.nginx-proxy.nginx-proxy.keepalive" | keys | first | default "auto" }}
 
         {{- $upstream := $vhost_data.upstream_name }}
         {{- if (not (eq $path "/")) }}

--- a/test/test_keepalive.yml
+++ b/test/test_keepalive.yml
@@ -8,6 +8,8 @@ services:
     environment:
       WEB_PORTS: 80
       VIRTUAL_HOST: keepalive-disabled.nginx-proxy.test
+    labels:
+      com.github.nginx-proxy.nginx-proxy.keepalive: "disabled"
 
   keepalive-enabled:
     image: web
@@ -29,8 +31,6 @@ services:
     environment:
       WEB_PORTS: 80
       VIRTUAL_HOST: keepalive-auto.nginx-proxy.test
-    labels:
-      com.github.nginx-proxy.nginx-proxy.keepalive: "auto"
 
   sut:
     image: nginxproxy/nginx-proxy:test


### PR DESCRIPTION
This PR [enable HTTP keepalive by default](https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#no-keepalives) with the `auto` setting.