### PR TITLE
chore: changes from upstream docker install

### DIFF
--- a/test/requirements/Dockerfile-nginx-proxy-tester
+++ b/test/requirements/Dockerfile-nginx-proxy-tester
@@ -10,14 +10,13 @@ RUN apt-get update \
   && apt-get install -y \
     ca-certificates \
     curl \
-    gnupg \
   && install -m 0755 -d /etc/apt/keyrings \
-  && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
-  && chmod a+r /etc/apt/keyrings/docker.gpg
+  && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+  && chmod a+r /etc/apt/keyrings/docker.asc
 
 # Add the Docker repository to Apt sources
 RUN echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
   tee /etc/apt/sources.list.d/docker.list > /dev/null
 


### PR DESCRIPTION
Incorporate changes from [the official install instructions](https://docs.docker.com/engine/install/debian/).

https://github.com/docker/docs/commit/33befd692249d11ce7bc88052d82709a07a8107f
Fix apt-get ascii GPG key
Changing the file extension for the GPG key to .asc lets apt-get know the GPG key is in ascii armor format, no need to dearmor.

https://github.com/docker/docs/commit/1b49c84d706d2e59b8f2300a0bdf408224ba7fc6
engine: add chmod a+r for gpg key

https://github.com/docker/docs/commit/6dc6f503e71f8f5bdce72efb50f712b5d8a371c2
engine: remove gnupg from install prerequisites