### PR TITLE
fix: wildcard certificates should only work one level deep

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -688,13 +688,25 @@ proxy_set_header Proxy "";
         {{ $vhost_containers = concat $vhost_containers $vpath_containers }}
     {{- end }}
 
-    {{- $certName := groupByKeys $vhost_containers "Env.CERT_NAME" | first }}
-    {{- $vhostCert := closest (dir "/etc/nginx/certs") (printf "%s.crt" $hostname) }}
-    {{- $vhostCert = trimSuffix ".crt" $vhostCert }}
-    {{- $vhostCert = trimSuffix ".key" $vhostCert }}
+    {{- $userIdentifiedCert := groupByKeys $vhost_containers "Env.CERT_NAME" | first }}
+    
+    {{- $vhostCert := "" }}
+    {{- if exists (printf "/etc/nginx/certs/%s.crt" $hostname) }}
+        {{- $vhostCert = $hostname }}
+    {{- end }}
+
+    {{- $parentVhostCert := "" }}
+    {{- if gt ($hostname | sprigSplit "." | len) 2 }}
+        {{- $parentHostname := ($hostname | sprigSplitn "." 2)._1 }}
+        {{- if exists (printf "/etc/nginx/certs/%s.crt" $parentHostname) }}
+            {{- $parentVhostCert = $parentHostname }}
+        {{- end }}
+    {{- end }}
+    
     {{- $trust_default_cert := groupByLabel $vhost_containers "com.github.nginx-proxy.nginx-proxy.trust-default-cert" | keys | first | default $globals.config.trust_default_cert | parseBool }}
-    {{- $cert := and $trust_default_cert $globals.config.default_cert_ok | ternary "default" "" }}
-    {{- $cert = or $certName $vhostCert $cert }}
+    {{- $defaultCert := and $trust_default_cert $globals.config.default_cert_ok | ternary "default" "" }}
+    
+    {{- $cert := or $userIdentifiedCert $vhostCert $parentVhostCert $defaultCert }}
     {{- $cert_ok := and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert)) }}
 
     {{- $enable_debug_endpoint := groupByLabel $vhost_containers "com.github.nginx-proxy.nginx-proxy.debug-endpoint" | keys | first | default $globals.config.enable_debug_endpoint | parseBool }}

--- a/test/test_ssl/test_cert_selection.py
+++ b/test/test_ssl/test_cert_selection.py
@@ -1,0 +1,25 @@
+import json
+import pytest
+
+
+@pytest.mark.parametrize("host,expected_cert_ok,expected_cert", [
+    ("nginx-proxy.tld", True, "nginx-proxy.tld"),
+    ("web1.nginx-proxy.tld", True, "nginx-proxy.tld"),
+    ("sub.web1.nginx-proxy.tld", False, ""),
+    ("web2.nginx-proxy.tld", True, "web2.nginx-proxy.tld"),
+])
+def test_certificate_selection(
+    docker_compose,
+    nginxproxy,
+    host: str,
+    expected_cert_ok: bool,
+    expected_cert: str,
+):
+    r = nginxproxy.get(f"http://{host}/nginx-proxy-debug")
+    assert r.status_code == 200
+    try:
+        jsonResponse = json.loads(r.text)
+    except ValueError as err:
+        pytest.fail("Failed to parse debug endpoint response as JSON:: %s" % err, pytrace=False)
+    assert jsonResponse["vhost"]["cert_ok"] == expected_cert_ok
+    assert jsonResponse["vhost"]["cert"] == expected_cert

--- a/test/test_ssl/test_cert_selection.yml
+++ b/test/test_ssl/test_cert_selection.yml
@@ -1,0 +1,33 @@
+services:
+  base:
+      image: web
+      environment:
+        WEB_PORTS: "80"
+        VIRTUAL_HOST: "nginx-proxy.tld"
+
+  web1:
+      image: web
+      environment:
+        WEB_PORTS: "80"
+        VIRTUAL_HOST: "web1.nginx-proxy.tld"
+  
+  sub-web1:
+      image: web
+      environment:
+        WEB_PORTS: "80"
+        VIRTUAL_HOST: "sub.web1.nginx-proxy.tld"
+
+  web2:
+      image: web
+      environment:
+        WEB_PORTS: "80"
+        VIRTUAL_HOST: "web2.nginx-proxy.tld"
+
+  sut:
+    image: nginxproxy/nginx-proxy:test
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ./certs:/etc/nginx/certs:ro
+      - ./acme_root:/usr/share/nginx/html:ro
+    environment:
+      DEBUG_ENDPOINT: "true"


### PR DESCRIPTION
This PR closes #176 

As explained by @DonDebonair in the issue, wildcard certificate do not work the way nginx-proxy is currently trying to use them: a wildcard certificate for `*.example.com` will be valid for `foo.example.com` and `bar.example.com` but not for `sub.foo.example.com`.