### PR TITLE
ci: python 3.12+ compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Install dependencies
         run: |

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,7 @@ import docker
 import pytest
 import requests
 from _pytest._code.code import ReprExceptionInfo
-from distutils.version import LooseVersion
+from packaging.version import Version
 from docker.models.containers import Container
 from requests.packages.urllib3.util.connection import HAS_IPV6
 
@@ -557,5 +557,5 @@ try:
 except docker.errors.ImageNotFound:
     pytest.exit("The docker image 'nginxproxy/nginx-proxy:test' is missing")
 
-if LooseVersion(docker.__version__) < LooseVersion("5.0.0"):
+if Version(docker.__version__) < Version("5.0.0"):
     pytest.exit("This test suite is meant to work with the python docker module v5.0.0 or later")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -557,5 +557,5 @@ try:
 except docker.errors.ImageNotFound:
     pytest.exit("The docker image 'nginxproxy/nginx-proxy:test' is missing")
 
-if Version(docker.__version__) < Version("5.0.0"):
-    pytest.exit("This test suite is meant to work with the python docker module v5.0.0 or later")
+if Version(docker.__version__) < Version("7.0.0"):
+    pytest.exit("This test suite is meant to work with the python docker module v7.0.0 or later")

--- a/test/requirements/Dockerfile-nginx-proxy-tester
+++ b/test/requirements/Dockerfile-nginx-proxy-tester
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.12
 
 ENV PYTEST_RUNNING_IN_CONTAINER=1
 

--- a/test/test_dockergen/test_dockergen.py
+++ b/test/test_dockergen/test_dockergen.py
@@ -1,11 +1,11 @@
 import docker
 import pytest
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 
 raw_version = docker.from_env().version()["Version"]
 pytestmark = pytest.mark.skipif(
-    LooseVersion(raw_version) < LooseVersion("1.13"),
+    Version(raw_version) < Version("1.13"),
     reason="Docker compose syntax v3 requires docker engine v1.13 or later (got {raw_version})"
 )
 


### PR DESCRIPTION
Python 3.9 will reach EOL 31 Oct 2025. But in my environment they already removed it. And the tests were failing because of `distutils.version` is deprecated since Python 3.10 and [removed](https://docs.python.org/3.12/whatsnew/3.12.html#distutils) in Python 3.12

`distutils.version` should be [replaced ](https://peps.python.org/pep-0632/#migration-advice)with the `packaging` package

This makes the test suite compatible with Python 3.12 and also 3.13. But since Python 3.13 is [not cached](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#python) in the action runner image I used Python 3.12 for now.

Changed the python module version check to 7.0.0 as that [adds official compatibility](https://docker-py.readthedocs.io/en/7.0.0/change-log.html#features). And we use 7+ anyway.
