### PR TITLE
Add possibility to handle multiple network tags

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -289,9 +289,11 @@
     {{- else }}
         {{- $keepalive := $vpath.keepalive }}
     location {{ .Path }} {
-        {{- if eq $vpath.network_tag "internal" }}
-        # Only allow traffic from internal clients
-        include /etc/nginx/network_internal.conf;
+        {{- if not (eq $vpath.network_tag "external") }}
+            {{- if exists (printf "/etc/nginx/network_%s.conf" $vpath.network_tag) }}
+        # Only allow traffic from {{ $vpath.network_tag }} clients
+        include {{ printf "/etc/nginx/network_%s.conf" $vpath.network_tag }};
+            {{- end }}
         {{- end }}
 
         {{ $proto := $vpath.proto }}


### PR DESCRIPTION
Very concise update, but basically this gives the possibility of handling different network access depending on the docker service.

The user would need to expose the corresponding files for each group :

```yaml
volumes:
      - ./network_internal.conf:/etc/nginx/network_internal.conf
      - ./network_group0.conf:/etc/nginx/network_group0.conf
      - ./network_group1.conf:/etc/nginx/network_group1.conf
      - ./network_group2.conf:/etc/nginx/network_group2.conf
      - ./network_group3.conf:/etc/nginx/network_group3.conf
```

Just sharing that as I've been using it. Let me know if that helps anybody.