### PR TITLE
tests: DockerComposer contextmanager improvements 

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -428,9 +428,15 @@ def connect_to_network(network: Network) -> Optional[Network]:
         # Make sure our container is connected to the nginx-proxy's network,
         # but avoid connecting to `none` network (not valid) with `test_server-down` tests
         if network.name not in my_networks and network.name != 'none':
-            logging.info(f"Connecting to docker network: {network.name}")
-            network.connect(my_container)
-            return network
+            try:
+                logging.info(f"Connecting to docker network: {network.name}")
+                network.connect(my_container)
+                return network
+            except docker.errors.APIError as e:
+                logging.warning(f"Failed to connect to network {network.name}: {e}")
+                return network  # Ensure the network is still tracked for later removal
+
+    return None
 
 
 def disconnect_from_network(network: Network = None):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -321,11 +321,11 @@ def __prepare_and_execute_compose_cmd(compose_files: List[str], project_name: st
         compose_cmd.write(f" --file {compose_file}")
     compose_cmd.write(f" {cmd}")
 
-    logging.info(compose_cmd.getvalue())
     try:
         subprocess.check_output(shlex.split(compose_cmd.getvalue()), stderr=subprocess.STDOUT)
+        logging.info(f"Executed '{compose_cmd.getvalue()}'")
     except subprocess.CalledProcessError as e:
-        pytest.fail(f"Error while running '{compose_cmd.getvalue()}':\n{e.output}", pytrace=False)
+        logging.error(f"Error while running '{compose_cmd.getvalue()}'")
 
 
 def docker_compose_up(compose_files: List[str], project_name: str):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -489,7 +489,7 @@ class DockerComposer(contextlib.AbstractContextManager):
             for network in self._networks:
                 disconnect_from_network(network)
         docker_compose_down(self._docker_compose_files, self._project_name)
-        self._docker_compose_file = None
+        self._docker_compose_files = None
         self._project_name = None
         self._networks = []
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -169,7 +169,7 @@ def container_ip(container: Container) -> str:
         net_info = container.attrs["NetworkSettings"]["Networks"]
         if "bridge" in net_info:
             return net_info["bridge"]["IPAddress"]
-        
+
         # container is running in host network mode
         if "host" in net_info:
             return "127.0.0.1"
@@ -186,7 +186,7 @@ def container_ipv6(container: Container) -> str:
     net_info = container.attrs["NetworkSettings"]["Networks"]
     if "bridge" in net_info:
         return net_info["bridge"]["GlobalIPv6Address"]
-    
+
     # container is running in host network mode
     if "host" in net_info:
         return "::1"
@@ -527,7 +527,7 @@ class DockerComposer(contextlib.AbstractContextManager):
             logging.debug(f"Full error message: {str(e)}")
             self._down()  # Ensure proper cleanup even on failure
             pytest.fail(f"Docker Compose setup failed due to Docker API error: {e.explanation}")
-            
+
         except RuntimeError as e:
             logging.error(f"RuntimeEror encountered in: {project_name}")
             logging.debug(f"Full error message: {str(e)}")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -511,6 +511,11 @@ class DockerComposer(contextlib.AbstractContextManager):
             wait_for_nginxproxy_to_be_ready()
             time.sleep(3)  # give time to containers to be ready
 
+        except KeyboardInterrupt:
+            logging.warning("KeyboardInterrupt detected! Force cleanup...")
+            self._down()  # Ensure proper shutdown
+            raise  # Re-raise to allow pytest to exit cleanly
+
         except docker.errors.APIError as e:
             logging.error(f"Docker API error ({e.status_code}): {e.explanation}")
             logging.debug(f"Full error message: {str(e)}")

--- a/test/test_custom/test_location-per-vhost.yml
+++ b/test/test_custom/test_location-per-vhost.yml
@@ -27,4 +27,4 @@ services:
       - "83"
     environment:
       WEB_PORTS: "83"
-      VIRTUAL_HOST: ~^regex.*\.nginx-proxy\.example$$
+      VIRTUAL_HOST: ~^regex.*\.nginx-proxy\.example$$ # we need to double the `$` because of docker compose variable interpolation

--- a/test/test_custom/test_per-vhost.yml
+++ b/test/test_custom/test_per-vhost.yml
@@ -27,4 +27,4 @@ services:
       - "83"
     environment:
       WEB_PORTS: "83"
-      VIRTUAL_HOST: ~^regex.*\.nginx-proxy\.example$$
+      VIRTUAL_HOST: ~^regex.*\.nginx-proxy\.example$$ # we need to double the `$` because of docker compose variable interpolation

--- a/test/test_host-network-mode/test_proxy-host-network-mode.py
+++ b/test/test_host-network-mode/test_proxy-host-network-mode.py
@@ -1,5 +1,15 @@
 # Note: on Docker Desktop, host networking must be manually enabled.
 # See https://docs.docker.com/engine/network/drivers/host/
+import os
+
+import pytest
+
+PYTEST_RUNNING_IN_CONTAINER = os.environ.get('PYTEST_RUNNING_IN_CONTAINER') == "1"
+
+pytestmark = pytest.mark.skipif(
+    PYTEST_RUNNING_IN_CONTAINER,
+    reason="Connecting to host network not supported when pytest is running in container"
+)
 
 def test_forwards_to_host_network_container_1(docker_compose, nginxproxy):
     r = nginxproxy.get("http://host-network-1.nginx-proxy.tld:8888/port")

--- a/test/test_htpasswd/test_htpasswd-regex-virtual-host.yml
+++ b/test/test_htpasswd/test_htpasswd-regex-virtual-host.yml
@@ -5,4 +5,4 @@ services:
       - "80"
     environment:
       WEB_PORTS: "80"
-      VIRTUAL_HOST: ~^regex.*\.nginx-proxy\.example$$
+      VIRTUAL_HOST: ~^regex.*\.nginx-proxy\.example$$ # we need to double the `$` because of docker compose variable interpolation


### PR DESCRIPTION
Improvements to the DockerComposer contextmanager as mentioned in https://github.com/nginx-proxy/nginx-proxy/pull/2584#pullrequestreview-2588289338

I run the test suite as container, and found that if errors occur or on keyboardinterrupt the containers and/or networks are not cleaned properly leaving ghost stuff around and preventing new test runs.
In Github CI not a problem because after tests the runner is terminated.

- Improve the DockerComposer contextmanager to make sure teardown happens by using try except block.
- Move the self. declarations up so we are sure they are set even if an exception occurs.
- set `self._networks`
- `self._docker_compose_file = None` >>` self._docker_compose_files = None` (files typo)
- Change pytest.fail to a logging error because `pytest.fail` makes DockerComposer ContextManager exit and no _down teardown is executed.
- Add KeyboardInterrupt logic
- skip test_proxy-host-network-mode when `PYTEST_RUNNING_IN_CONTAINER` as this does not work

A review from @pini-gh is highly appreciated to make sure Debian Stable is still OK.