### PR TITLE
docs: bump docker image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker run --detach \
     --name nginx-proxy \
     --publish 80:80 \
     --volume /var/run/docker.sock:/tmp/docker.sock:ro \
-    nginxproxy/nginx-proxy:1.6
+    nginxproxy/nginx-proxy:1.7
 ```
 
 Then start any containers (here an nginx container) you want proxied with an env var `VIRTUAL_HOST=subdomain.yourdomain.com`
@@ -48,7 +48,7 @@ The nginx-proxy images are available in two flavors.
 This image is based on the nginx:mainline image, itself based on the debian slim image.
 
 ```console
-docker pull nginxproxy/nginx-proxy:1.6
+docker pull nginxproxy/nginx-proxy:1.7
 ```
 
 #### Alpine based version (`-alpine` suffix)
@@ -56,7 +56,7 @@ docker pull nginxproxy/nginx-proxy:1.6
 This image is based on the nginx:alpine image.
 
 ```console
-docker pull nginxproxy/nginx-proxy:1.6-alpine
+docker pull nginxproxy/nginx-proxy:1.7-alpine
 ```
 
 > [!IMPORTANT]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1271,7 +1271,7 @@ curl -s -H "Host: test.nginx-proxy.tld" localhost/nginx-proxy-debug | jq
     "https_method": "redirect",
     "log_format": null,
     "log_format_escape": null,
-    "nginx_proxy_version": "1.6.3",
+    "nginx_proxy_version": "1.7.0",
     "resolvers": "127.0.0.11",
     "sha1_upstream_name": false,
     "ssl_policy": "Mozilla-Intermediate",


### PR DESCRIPTION
## Summary

The latest release version is [v1.7](https://github.com/nginx-proxy/nginx-proxy/releases/tag/1.7.0).
This PR updates the old ones in README.md.