### PR TITLE
Rename generated nginx config file to 50-default.conf to help ordering

### DIFF
--- a/app/Procfile
+++ b/app/Procfile
@@ -1,2 +1,2 @@
-dockergen: docker-gen -watch -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+dockergen: docker-gen -watch -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/50-default.conf
 nginx: nginx -g "daemon off;"

--- a/docker-compose-separate-containers.yml
+++ b/docker-compose-separate-containers.yml
@@ -12,7 +12,7 @@ services:
 
   dockergen:
     image: nginxproxy/docker-gen
-    command: -notify-sighup nginx -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+    command: -notify-sighup nginx -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/50-default.conf
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl

--- a/docs/README.md
+++ b/docs/README.md
@@ -1143,7 +1143,7 @@ Then start the docker-gen container with the shared volume and template:
 docker run --volumes-from nginx \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
     -v $(pwd):/etc/docker-gen/templates \
-    -t nginxproxy/docker-gen -notify-sighup nginx -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+    -t nginxproxy/docker-gen -notify-sighup nginx -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/50-default.conf
 ```
 
 Finally, start your containers with `VIRTUAL_HOST` environment variables.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -297,16 +297,16 @@ def restore_urllib_dns_resolver(getaddrinfo_func):
 
 def get_nginx_conf_from_container(container: Container) -> bytes:
     """
-    return the nginx /etc/nginx/conf.d/default.conf file content from a container
+    return the nginx /etc/nginx/conf.d/50-default.conf file content from a container
     """
     import tarfile
     from io import BytesIO
 
-    strm_generator, stat = container.get_archive('/etc/nginx/conf.d/default.conf')
+    strm_generator, stat = container.get_archive('/etc/nginx/conf.d/50-default.conf')
     strm_fileobj = BytesIO(b"".join(strm_generator))
 
     with tarfile.open(fileobj=strm_fileobj) as tf:
-        conffile = tf.extractfile('default.conf')
+        conffile = tf.extractfile('50-default.conf')
         return conffile.read()
 
 

--- a/test/test_dockergen/test_dockergen.base.yml
+++ b/test/test_dockergen/test_dockergen.base.yml
@@ -14,7 +14,7 @@ services:
 
   nginx-proxy-dockergen:
     image: nginxproxy/docker-gen
-    command: -notify-sighup nginx -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+    command: -notify-sighup nginx -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/50-default.conf
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ../../nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl

--- a/test/test_unreachable-network/README.md
+++ b/test/test_unreachable-network/README.md
@@ -27,21 +27,21 @@ webB_1          | starting a web server listening on port 82
 webA_1          | starting a web server listening on port 81
 reverseproxy    | forego     | starting dockergen.1 on port 5000
 reverseproxy    | forego     | starting nginx.1 on port 5100
-reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Generated '/etc/nginx/conf.d/default.conf' from 3 containers
+reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Generated '/etc/nginx/conf.d/50-default.conf' from 3 containers
 reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Running 'nginx -s reload'
 reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Error running notify command: nginx -s reload, exit status 1
 reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Watching docker events
-reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Contents of /etc/nginx/conf.d/default.conf did not change. Skipping notification 'nginx -s reload'
+reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Contents of /etc/nginx/conf.d/50-default.conf did not change. Skipping notification 'nginx -s reload'
 reverseproxy    | reverseproxy    | forego     | starting dockergen.1 on port 5000  <---- nginx-proxy container restarted
 reverseproxy    | forego     | starting nginx.1 on port 5100
-reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Generated '/etc/nginx/conf.d/default.conf' from 3 containers
+reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Generated '/etc/nginx/conf.d/50-default.conf' from 3 containers
 reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Running 'nginx -s reload'
 reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Error running notify command: nginx -s reload, exit status 1
 reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Watching docker events
-reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Contents of /etc/nginx/conf.d/default.conf did not change. Skipping notification 'nginx -s reload'
+reverseproxy    | dockergen.1 | 2017/02/20 01:10:24 Contents of /etc/nginx/conf.d/50-default.conf did not change. Skipping notification 'nginx -s reload'
 reverseproxy    | forego     | starting dockergen.1 on port 5000
 reverseproxy    | forego     | starting nginx.1 on port 5100
-reverseproxy    | nginx.1    | 2017/02/20 01:11:02 [emerg] 17#17: no servers are inside upstream in /etc/nginx/conf.d/default.conf:64
+reverseproxy    | nginx.1    | 2017/02/20 01:11:02 [emerg] 17#17: no servers are inside upstream in /etc/nginx/conf.d/50-default.conf:64
 reverseproxy    | forego     | starting nginx.1 on port 5200
 reverseproxy    | forego     | sending SIGTERM to nginx.1
 reverseproxy    | forego     | sending SIGTERM to dockergen.1

--- a/test/test_virtual-proto/test_virtual-proto.yml
+++ b/test/test_virtual-proto/test_virtual-proto.yml
@@ -2,7 +2,7 @@ services:
   ssl-app-single-port:
     image: nginx:alpine
     volumes:
-      - ${PYTEST_MODULE_PATH}/ssl-app-single-port.conf:/etc/nginx/conf.d/default.conf:ro
+      - ${PYTEST_MODULE_PATH}/ssl-app-single-port.conf:/etc/nginx/conf.d/50-default.conf:ro
       - ${PYTEST_MODULE_PATH}/nginx-proxy.tld.crt:/etc/nginx/certs/server.crt:ro
       - ${PYTEST_MODULE_PATH}/nginx-proxy.tld.key:/etc/nginx/certs/server.key:ro
     environment:
@@ -13,7 +13,7 @@ services:
   ssl-app-multi-ports:
     image: nginx:alpine
     volumes:
-      - ${PYTEST_MODULE_PATH}/ssl-app-multi-ports.conf:/etc/nginx/conf.d/default.conf:ro
+      - ${PYTEST_MODULE_PATH}/ssl-app-multi-ports.conf:/etc/nginx/conf.d/50-default.conf:ro
       - ${PYTEST_MODULE_PATH}/nginx-proxy.tld.crt:/etc/nginx/certs/server.crt:ro
       - ${PYTEST_MODULE_PATH}/nginx-proxy.tld.key:/etc/nginx/certs/server.key:ro
     environment:


### PR DESCRIPTION
Currently nginx-proxy puts its configuration into a file named default.conf which is included via include /etc/nginx/conf.d/*.conf; directive. The nginx configuration is order dependent, thus if users rely on anything in default.conf being ordered before or after their config file, they must choose the name for the config file accordingly. Currently the name must be something that comes either before or after default.conf in alphabetical order. This is confusing.

A simple fix for this is be to rename the generated config file from default.conf to have some number prepended, such as 50-default.conf. This commit implements exactly this.

Fixes https://github.com/nginx-proxy/nginx-proxy/issues/2593.