### PR TITLE
docs: Add a note about configuration ordering in /etc/nginx/conf.d

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -816,6 +816,11 @@ services:
 
 </details>
 
+> [!NOTE]
+> The filenames of extra configuration files affect the order in which configuration is applied.
+> nginx reads configuration from `/etc/nginx/conf.d` directory in alphabetical order.
+> Note that the configuration managed by nginx-proxy is placed at `/etc/nginx/conf.d/default.conf`.
+
 ### Per-VIRTUAL_HOST
 
 To add settings on a per-`VIRTUAL_HOST` basis, add your configuration file under `/etc/nginx/vhost.d`. Unlike in the proxy-wide case, which allows multiple config files with any name ending in `.conf`, the per-`VIRTUAL_HOST` file must be named exactly after the `VIRTUAL_HOST`, or if `VIRTUAL_HOST` is a regex, after the sha1 hash of the regex.


### PR DESCRIPTION
Users may not be aware that the filename chosen to add extra configuration in /etc/nginx/conf.d may interfere with nginx-proxy. nginx-proxy stores its configuration at /etc/nginx/conf.d/default.conf. Any files that come before default.conf in alphabetical order will be applied before default.conf and vice-versa.

This is confusing, because the documentation does not specify how exactly nginx-proxy interacts with nginx.

This can be remedied by a simple note alerting the users of the importance of filename choices.

Fixes https://github.com/nginx-proxy/nginx-proxy/issues/2593.