### PR TITLE
fix(ci): correctly grab docker-gen version from dockerfile

### DIFF
--- a/.github/workflows/build-publish-dispatch.yml
+++ b/.github/workflows/build-publish-dispatch.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Retrieve docker-gen version
         id: docker-gen_version
-        run: sed -n -e 's;^FROM nginxproxy/docker-gen:\([0-9.]*\).*;VERSION=\1;p' Dockerfile.${{ matrix.base }} >> "$GITHUB_OUTPUT"
+        run: sed -n -e 's;^FROM docker.io/nginxproxy/docker-gen:\([0-9.]*\).*;VERSION=\1;p' Dockerfile.${{ matrix.base }} >> "$GITHUB_OUTPUT"
 
       - name: Get Docker tags
         id: docker_meta

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Retrieve docker-gen version
         id: docker-gen_version
-        run: sed -n -e 's;^FROM nginxproxy/docker-gen:\([0-9.]*\).*;VERSION=\1;p' Dockerfile.${{ matrix.base }} >> "$GITHUB_OUTPUT"
+        run: sed -n -e 's;^FROM docker.io/nginxproxy/docker-gen:\([0-9.]*\).*;VERSION=\1;p' Dockerfile.${{ matrix.base }} >> "$GITHUB_OUTPUT"
 
       - name: Get Docker tags
         id: docker_meta


### PR DESCRIPTION
`DOCKER_GEN_VERSION` was no longer correctly set since https://github.com/nginx-proxy/nginx-proxy/pull/2445