### PR TITLE
test: fix docker-gen tests flakyness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       matrix:
         base_docker_image: [alpine, debian]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -211,7 +211,7 @@ def nginx_proxy_dns_resolver(domain_name: str) -> Optional[str]:
         nginx_containers = docker_client.containers.list(filters={"status": "running", "ancestor": "nginx:latest"})
 
         if len(nginxproxy_containers) == 0 and len(nginx_containers) == 0:
-            log.warning(f"no runninf container found from image nginxproxy/nginx-proxy:test or nginx:latest while resolving {domain_name!r}")
+            log.warning(f"no running container found from image nginxproxy/nginx-proxy:test or nginx:latest while resolving {domain_name!r}")
 
             exited_nginxproxy_containers = docker_client.containers.list(filters={"status": "exited", "ancestor": "nginxproxy/nginx-proxy:test"})
             exited_nginx_containers = docker_client.containers.list(filters={"status": "exited", "ancestor": "nginx:latest"})

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -370,27 +370,20 @@ def docker_compose_down(compose_files: List[str], project_name: str):
 
 def wait_for_nginxproxy_to_be_ready():
     """
-    If one (and only one) container started from image nginxproxy/nginx-proxy:test
-    or nginxproxy/docker-gen:latest is found, wait for its log to contain the substring "Watching docker events"
+    Wait for logs of running containers started from image nginxproxy/nginx-proxy:test and/or
+    nginxproxy/docker-gen:latest to contain the substring "Watching docker events"
     """
-    nginx_proxy_containers = docker_client.containers.list(filters={"ancestor": "nginxproxy/nginx-proxy:test"})
-    docker_gen_containers = docker_client.containers.list(filters={"ancestor": "nginxproxy/docker-gen:latest"})
+    nginx_proxy_containers = docker_client.containers.list(filters={"status": "running", "ancestor": "nginxproxy/nginx-proxy:test"})
+    docker_gen_containers = docker_client.containers.list(filters={"status": "running", "ancestor": "nginxproxy/docker-gen:latest"})
 
-    container_name = "nginx-proxy"
+    containers = nginx_proxy_containers + docker_gen_containers
 
-    if len(nginx_proxy_containers) == 1:
-        container = nginx_proxy_containers.pop()
-    elif len(docker_gen_containers) == 1:
-        container = docker_gen_containers.pop()
-        container_name = "docker-gen"
-    else:
-        logging.debug("Either more than one or no nginx-proxy or docker-gen container found, skipping container readiness check")
-        return
-
-    for line in container.logs(stream=True):
-        if b"Watching docker events" in line:
-            logging.debug(f"{container_name} ready")
-            break
+    for container in containers:
+        logging.debug(f"waiting for container {container.name} to be ready")
+        for line in container.logs(stream=True):
+            if b"Watching docker events" in line:
+                logging.debug(f"{container.name} ready")
+                break
 
 
 @pytest.fixture

--- a/test/test_dockergen/test_dockergen.base.yml
+++ b/test/test_dockergen/test_dockergen.base.yml
@@ -27,4 +27,4 @@ services:
       - "80"
     environment:
       WEB_PORTS: "80"
-      VIRTUAL_HOST: whoami.nginx.container.docker
+      VIRTUAL_HOST: whoami.nginx-proxy.tld

--- a/test/test_dockergen/test_dockergen.py
+++ b/test/test_dockergen/test_dockergen.py
@@ -11,12 +11,12 @@ pytestmark = pytest.mark.skipif(
 
 
 def test_unknown_virtual_host_is_503(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://unknown.nginx.container.docker/")
+    r = nginxproxy.get("http://unknown.nginx-proxy.tld/")
     assert r.status_code == 503
 
 
 def test_forwards_to_whoami(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://whoami.nginx.container.docker/")
+    r = nginxproxy.get("http://whoami.nginx-proxy.tld/")
     assert r.status_code == 200
     whoami_container = docker_compose.containers.get("whoami")
     assert r.text == f"I'm {whoami_container.id[:12]}\n"

--- a/test/test_dockergen/test_dockergen.py
+++ b/test/test_dockergen/test_dockergen.py
@@ -1,15 +1,3 @@
-import docker
-import pytest
-from packaging.version import Version
-
-
-raw_version = docker.from_env().version()["Version"]
-pytestmark = pytest.mark.skipif(
-    Version(raw_version) < Version("1.13"),
-    reason="Docker compose syntax v3 requires docker engine v1.13 or later (got {raw_version})"
-)
-
-
 def test_unknown_virtual_host_is_503(docker_compose, nginxproxy):
     r = nginxproxy.get("http://unknown.nginx-proxy.tld/")
     assert r.status_code == 503
@@ -20,8 +8,3 @@ def test_forwards_to_whoami(docker_compose, nginxproxy):
     assert r.status_code == 200
     whoami_container = docker_compose.containers.get("whoami")
     assert r.text == f"I'm {whoami_container.id[:12]}\n"
-
-
-if __name__ == "__main__":
-    import doctest
-    doctest.testmod()

--- a/test/test_dockergen/test_dockergen_network_segregation-custom-label.base.yml
+++ b/test/test_dockergen/test_dockergen_network_segregation-custom-label.base.yml
@@ -40,6 +40,6 @@ services:
       - "80"
     environment:
       WEB_PORTS: "80"
-      VIRTUAL_HOST: whoami2.nginx.container.docker
+      VIRTUAL_HOST: whoami2.nginx-proxy.tld
     networks:
       - proxy

--- a/test/test_dockergen/test_dockergen_network_segregation-custom-label.py
+++ b/test/test_dockergen/test_dockergen_network_segregation-custom-label.py
@@ -11,12 +11,12 @@ pytestmark = pytest.mark.skipif(
 
 
 def test_unknown_virtual_host_is_503(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://unknown.nginx.container.docker/")
+    r = nginxproxy.get("http://unknown.nginx-proxy.tld/")
     assert r.status_code == 503
 
 
 def test_forwards_to_whoami(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://whoami2.nginx.container.docker/")
+    r = nginxproxy.get("http://whoami2.nginx-proxy.tld/")
     assert r.status_code == 200
     whoami_container = docker_compose.containers.get("whoami2")
     assert r.text == f"I'm {whoami_container.id[:12]}\n"

--- a/test/test_dockergen/test_dockergen_network_segregation-custom-label.py
+++ b/test/test_dockergen/test_dockergen_network_segregation-custom-label.py
@@ -1,15 +1,3 @@
-import docker
-import pytest
-from packaging.version import Version
-
-
-raw_version = docker.from_env().version()["Version"]
-pytestmark = pytest.mark.skipif(
-    Version(raw_version) < Version("1.13"),
-    reason="Docker compose syntax v3 requires docker engine v1.13 or later (got {raw_version})"
-)
-
-
 def test_unknown_virtual_host_is_503(docker_compose, nginxproxy):
     r = nginxproxy.get("http://unknown.nginx-proxy.tld/")
     assert r.status_code == 503
@@ -20,8 +8,3 @@ def test_forwards_to_whoami(docker_compose, nginxproxy):
     assert r.status_code == 200
     whoami_container = docker_compose.containers.get("whoami2")
     assert r.text == f"I'm {whoami_container.id[:12]}\n"
-
-
-if __name__ == "__main__":
-    import doctest
-    doctest.testmod()

--- a/test/test_dockergen/test_dockergen_network_segregation.base.yml
+++ b/test/test_dockergen/test_dockergen_network_segregation.base.yml
@@ -38,6 +38,6 @@ services:
       - "80"
     environment:
       WEB_PORTS: "80"
-      VIRTUAL_HOST: whoami2.nginx.container.docker
+      VIRTUAL_HOST: whoami2.nginx-proxy.tld
     networks:
       - proxy

--- a/test/test_dockergen/test_dockergen_network_segregation.py
+++ b/test/test_dockergen/test_dockergen_network_segregation.py
@@ -11,12 +11,12 @@ pytestmark = pytest.mark.skipif(
 
 
 def test_unknown_virtual_host_is_503(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://unknown.nginx.container.docker/")
+    r = nginxproxy.get("http://unknown.nginx-proxy.tld/")
     assert r.status_code == 503
 
 
 def test_forwards_to_whoami(docker_compose, nginxproxy):
-    r = nginxproxy.get("http://whoami2.nginx.container.docker/")
+    r = nginxproxy.get("http://whoami2.nginx-proxy.tld/")
     assert r.status_code == 200
     whoami_container = docker_compose.containers.get("whoami2")
     assert r.text == f"I'm {whoami_container.id[:12]}\n"

--- a/test/test_dockergen/test_dockergen_network_segregation.py
+++ b/test/test_dockergen/test_dockergen_network_segregation.py
@@ -1,15 +1,3 @@
-import docker
-import pytest
-from packaging.version import Version
-
-
-raw_version = docker.from_env().version()["Version"]
-pytestmark = pytest.mark.skipif(
-    Version(raw_version) < Version("1.13"),
-    reason="Docker compose syntax v3 requires docker engine v1.13 or later (got {raw_version})"
-)
-
-
 def test_unknown_virtual_host_is_503(docker_compose, nginxproxy):
     r = nginxproxy.get("http://unknown.nginx-proxy.tld/")
     assert r.status_code == 503
@@ -20,8 +8,3 @@ def test_forwards_to_whoami(docker_compose, nginxproxy):
     assert r.status_code == 200
     whoami_container = docker_compose.containers.get("whoami2")
     assert r.text == f"I'm {whoami_container.id[:12]}\n"
-
-
-if __name__ == "__main__":
-    import doctest
-    doctest.testmod()


### PR DESCRIPTION
Tests introduced in #2279 where very flaky because they used the `docker_container_dns_resolver`, this PR should fix this.

I've ran the tests on this branch four times in a row without issue.

@SchoNie could you confirm ?