### PR TITLE
fix: set auth_request off for all acme challenge locations

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -865,6 +865,7 @@ server {
         {{- if $globals.config.acme_http_challenge_accept_unknown_host }}
     location ^~ /.well-known/acme-challenge/ {
         auth_basic off;
+        auth_request off;
         allow all;
         root /usr/share/nginx/html;
         try_files $uri =404;
@@ -970,6 +971,7 @@ server {
         {{- if (and (eq $vhost.https_method "noredirect") $vhost.acme_http_challenge_enabled) }}
     location /.well-known/acme-challenge/ {
         auth_basic off;
+        auth_request off;
         allow all;
         root /usr/share/nginx/html;
         try_files $uri =404;


### PR DESCRIPTION
Adds missing `auth_request off;` to a few `.well-known/acme-challenge` location blocks.

This is needed to allow unrestricted access to `.well-known/acme-challenge` files on servers where `auth_request` is otherwise globally applied.

See #1409, nginx-proxy/acme-companion#570