### PR TITLE
feat: pass X-Real-IP header to gRPC Backend

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -321,8 +321,10 @@
             {{- end }}
         {{- else if eq $proto "grpc" }}
         grpc_pass {{ trim $proto }}://{{ trim $upstream }};
+        grpc_set_header X-Real-IP $remote_addr;
         {{- else if eq $proto "grpcs" }}
         grpc_pass {{ trim $proto }}://{{ trim $upstream }};
+        grpc_set_header X-Real-IP $remote_addr;
         {{- else }}
         proxy_pass {{ trim $proto }}://{{ trim $upstream }}{{ trim $dest }};
         set $upstream_keepalive {{ if ne $keepalive "disabled" }}true{{ else }}false{{ end }};


### PR DESCRIPTION
Hi. This pull request adds the ability to forward the client's real IP address to the gRPC backend.

gRPC backend can get the real IP address of the client using a similar snippet:

```go
func UserIP(ctx context.Context) string {
	md, ok := metadata.FromIncomingContext(ctx)
	if ok {
		if xRealIP := md.Get("x-real-ip"); len(xRealIP) > 0 {
			return strings.Split(xRealIP[0], ",")[0]
		}
	}
	p, ok := peer.FromContext(ctx)
	if ok {
		return p.Addr.String()
	}
	return ""
}
```