### PR TITLE
RFC: feat: Support multiple networks by running multiple instances of nginx-proxy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1326,6 +1326,15 @@ I'm 5b129ab83266
 
 ⬆️ [back to table of contents](#table-of-contents)
 
+## Managing multiple networks
+
+It is possible to manage multiple independent networks on single host by running multiple instances of nginx-proxy.
+In order to support this, set `VIRTUAL_HOST_ENV_PREFIX` environment variable to a different value on each of nginx-proxy instance (default is `VIRTUAL_HOST`).
+The containers will then be configured using the value of `${VIRTUAL_HOST_ENV_PREFIX}` and `${VIRTUAL_HOST_ENV_PREFIX}_MULTIPORTS` environment variables instead of `VIRTUAL_HOST` and `VIRTUAL_HOST_MULTIPORTS`.
+Each nginx-proxy instance will connect only to the containers that have corresponding environment variables set.
+
+⬆️ [back to table of contents](#table-of-contents)
+
 ## Configuration summary
 
 This section summarize the configurations available on the proxy and proxied container.
@@ -1364,6 +1373,7 @@ Configuration available either on the nginx-proxy container, or the docker-gen c
 | [`SSL_POLICY`](#how-ssl-support-works) | `Mozilla-Intermediate` |
 | [`TRUST_DEFAULT_CERT`](#default-and-missing-certificate) | `true` |
 | [`TRUST_DOWNSTREAM_PROXY`](#trusting-downstream-proxy-headers) | `true` |
+| [`VIRTUAL_HOST_ENV_PREFIX`](#managing-multiple-networks) | `VIRTUAL_HOST` |
 
 ### Proxyied container
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -598,8 +598,10 @@ proxy_set_header X-Original-URI $request_uri;
 proxy_set_header Proxy "";
 {{- end }}
 
+{{- $virtualHostEnvPrefix := $globals.Env.VIRTUAL_HOST_ENV_PREFIX | default "VIRTUAL_HOST" }}
+
 {{- /* Precompute and store some information about vhost that use VIRTUAL_HOST_MULTIPORTS. */}}
-{{- range $vhosts_yaml, $containers := groupBy $globals.containers "Env.VIRTUAL_HOST_MULTIPORTS" }}
+{{- range $vhosts_yaml, $containers := groupBy $globals.containers (printf "Env.%s_MULTIPORTS" $virtualHostEnvPrefix) }}
     {{- /* Print a warning in the config if VIRTUAL_HOST_MULTIPORTS can't be parsed. */}}
     {{- $parsedVhosts := fromYaml $vhosts_yaml }}
     {{- if (empty $parsedVhosts) }}
@@ -655,7 +657,7 @@ proxy_set_header Proxy "";
 {{- end }}
 
 {{- /* Precompute and store some information about vhost that use VIRTUAL_HOST. */}}
-{{- range $hostname, $containers := groupByMulti $globals.containers "Env.VIRTUAL_HOST" "," }}
+{{- range $hostname, $containers := groupByMulti $globals.containers (printf "Env.%s" $virtualHostEnvPrefix) "," }}
     {{- /* Ignore containers with VIRTUAL_HOST set to the empty string. */}}
     {{- $hostname = trim $hostname }}
     {{- if not $hostname }}
@@ -665,7 +667,7 @@ proxy_set_header Proxy "";
     {{- /* Drop containers with both VIRTUAL_HOST and VIRTUAL_HOST_MULTIPORTS set
          * (VIRTUAL_HOST_MULTIPORTS takes precedence thanks to the previous loop).
          */}}
-    {{- range $_, $containers_to_drop := groupBy $containers "Env.VIRTUAL_HOST_MULTIPORTS" }}
+    {{- range $_, $containers_to_drop := groupBy $containers (printf "Env.%s_MULTIPORTS" $virtualHostEnvPrefix) }}
         {{- range $container := $containers_to_drop }}
             {{- $containers = without $containers $container }}
         {{- end }}

--- a/test/test_vhost-prefix/test_vhost-prefix.py
+++ b/test/test_vhost-prefix/test_vhost-prefix.py
@@ -1,0 +1,10 @@
+def test_web1_vhost_prefix(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://web1.nginx-proxy.tld:80/port", allow_redirects=False)
+    assert r.status_code == 200
+    assert "answer from port 80\n" in r.text
+
+
+def test_web1_other_vhost_prefix_no_answer(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://web2.nginx-proxy.tld:80/port", allow_redirects=False)
+    assert r.status_code == 503
+

--- a/test/test_vhost-prefix/test_vhost-prefix.yml
+++ b/test/test_vhost-prefix/test_vhost-prefix.yml
@@ -1,0 +1,20 @@
+services:
+  nginx-proxy:
+    environment:
+      VIRTUAL_HOST_ENV_PREFIX: VHOST_CUSTOM
+
+  web1:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: "80"
+      VHOST_CUSTOM: "web1.nginx-proxy.tld"
+
+  web2:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: "80"
+      VIRTUAL_HOST: "web2.nginx-proxy.tld"


### PR DESCRIPTION
I'm not sure if it makes sense nginx-proxy to support a feature like this, but I already have a proof of concept and instead of opening an issue a PR was created straight away. Let me know if the feature itself makes sense and I will rewrite PR in any way needed.

----- 

This feature is useful in cases there are multiple networks to be managed with nginx-proxy on the same host. For example, a public network and a network that can only be reached through a VPN.

This commit makes it possible to use multiple instances of nginx-proxy in such use cases. Each instance has a separate "namespace" of VIRTUAL_HOST and VIRTUAL_HOST_MULTIPORTS variables used by containers, controlled by VIRTUAL_HOST_ENV_PREFIX environment variable set on the nginx-proxy. E.g. set VIRTUAL_HOST_ENV_PREFIX=VIRTUAL_HOST_MY_NETWORK, and only containers with VIRTUAL_HOST_MY_NETWORK=something will be managed by that nginx-proxy instance.