### PR TITLE
Add nginx directive configuration via environment variables

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 - [HTTP/2 and HTTP/3](#http2-and-http3)
 - [Headers](#headers)
 - [Custom Nginx Configuration](#custom-nginx-configuration)
+  - [Virtual nginx directive configuration via environment variables](#virtual-nginx-directive-configuration-via-environment-variables)
 - [TCP and UDP stream](#tcp-and-udp-stream)
 - [Unhashed vs SHA1 upstream names](#unhashed-vs-sha1-upstream-names)
 - [Filtering containers](#filtering-containers)
@@ -977,6 +978,87 @@ services:
 > nginx reads configuration from `/etc/nginx/conf.d` directory in alphabetical order.
 > Note that the configuration managed by nginx-proxy is placed at `/etc/nginx/conf.d/default.conf`.
 
+### Virtual nginx directive configuration via environment variables
+
+Instead of mounting custom configuration files, a number of common nginx directives can be configured directly via environment variables. This feature must first be enabled on the **proxy container** by setting `ENABLE_VIRTUAL_CONFIG=true`.
+
+With this feature enabled, each directive can be set globally (affecting all virtual hosts) by setting the corresponding environment variable on the proxy container, or per virtual host by setting it on the proxied container. The environment variable name is `VIRTUAL_<DIRECTIVE_UPPERCASE>`, where `<DIRECTIVE_UPPERCASE>` is the nginx directive name in upper case with underscores.
+
+For example, to set `client_max_body_size` globally:
+
+```yaml
+services:
+  proxy:
+    image: nginxproxy/nginx-proxy
+    environment:
+      - ENABLE_VIRTUAL_CONFIG=true
+      - VIRTUAL_CLIENT_MAX_BODY_SIZE=100m
+```
+
+Or per virtual host on the proxied container:
+
+```yaml
+services:
+  app:
+    image: my-app
+    environment:
+      - VIRTUAL_HOST=app.example.com
+      - VIRTUAL_CLIENT_MAX_BODY_SIZE=500m
+```
+
+Directives that can appear multiple times in nginx (e.g. `set_real_ip_from`) can be specified as a semicolon-separated list:
+
+```yaml
+environment:
+  - VIRTUAL_SET_REAL_IP_FROM=10.0.0.0/8;172.16.0.0/12;192.168.0.0/16
+```
+
+This will emit one `set_real_ip_from` directive per value.
+
+> [!IMPORTANT]
+> All values are validated against a format pattern before being emitted. Values that do not match the expected nginx syntax are silently ignored. Refer to the [nginx documentation](https://nginx.org/en/docs/) for the accepted syntax of each directive.
+
+The following directives are supported:
+
+| Environment variable | nginx directive | Accepted format |
+|---|---|---|
+| `VIRTUAL_CLIENT_BODY_BUFFER_SIZE` | [`client_body_buffer_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size) | size (`1k`, `2m`, …) |
+| `VIRTUAL_CLIENT_BODY_TIMEOUT` | [`client_body_timeout`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_timeout) | time (`60s`, `1m`, …) |
+| `VIRTUAL_CLIENT_HEADER_BUFFER_SIZE` | [`client_header_buffer_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size) | size |
+| `VIRTUAL_CLIENT_HEADER_TIMEOUT` | [`client_header_timeout`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_timeout) | time |
+| `VIRTUAL_CLIENT_MAX_BODY_SIZE` | [`client_max_body_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) | size |
+| `VIRTUAL_IGNORE_INVALID_HEADERS` | [`ignore_invalid_headers`](https://nginx.org/en/docs/http/ngx_http_core_module.html#ignore_invalid_headers) | `on` or `off` |
+| `VIRTUAL_KEEPALIVE_REQUESTS` | [`keepalive_requests`](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive_requests) | integer |
+| `VIRTUAL_KEEPALIVE_TIMEOUT` | [`keepalive_timeout`](https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout) | time |
+| `VIRTUAL_LARGE_CLIENT_HEADER_BUFFERS` | [`large_client_header_buffers`](https://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers) | `<number> <size>` (e.g. `4 8k`) |
+| `VIRTUAL_PROXY_BUFFER_SIZE` | [`proxy_buffer_size`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size) | size |
+| `VIRTUAL_PROXY_BUFFERING` | [`proxy_buffering`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering) | `on` or `off` |
+| `VIRTUAL_PROXY_BUFFERS` | [`proxy_buffers`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) | `<number> <size>` |
+| `VIRTUAL_PROXY_BUSY_BUFFERS_SIZE` | [`proxy_busy_buffers_size`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_busy_buffers_size) | size |
+| `VIRTUAL_PROXY_CONNECT_TIMEOUT` | [`proxy_connect_timeout`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_connect_timeout) | time |
+| `VIRTUAL_PROXY_INTERCEPT_ERRORS` | [`proxy_intercept_errors`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_intercept_errors) | `on` or `off` |
+| `VIRTUAL_PROXY_MAX_TEMP_FILE_SIZE` | [`proxy_max_temp_file_size`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_max_temp_file_size) | size |
+| `VIRTUAL_PROXY_NEXT_UPSTREAM_TIMEOUT` | [`proxy_next_upstream_timeout`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_timeout) | time |
+| `VIRTUAL_PROXY_NEXT_UPSTREAM_TRIES` | [`proxy_next_upstream_tries`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream_tries) | integer |
+| `VIRTUAL_PROXY_READ_TIMEOUT` | [`proxy_read_timeout`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout) | time |
+| `VIRTUAL_PROXY_REQUEST_BUFFERING` | [`proxy_request_buffering`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_request_buffering) | `on` or `off` |
+| `VIRTUAL_PROXY_SEND_TIMEOUT` | [`proxy_send_timeout`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout) | time |
+| `VIRTUAL_PROXY_SSL_SERVER_NAME` | [`proxy_ssl_server_name`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_server_name) | `on` or `off` |
+| `VIRTUAL_PROXY_SSL_SESSION_REUSE` | [`proxy_ssl_session_reuse`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_session_reuse) | `on` or `off` |
+| `VIRTUAL_PROXY_SSL_VERIFY` | [`proxy_ssl_verify`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_verify) | `on` or `off` |
+| `VIRTUAL_PROXY_SSL_VERIFY_DEPTH` | [`proxy_ssl_verify_depth`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_verify_depth) | integer |
+| `VIRTUAL_PROXY_TEMP_FILE_WRITE_SIZE` | [`proxy_temp_file_write_size`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_temp_file_write_size) | size |
+| `VIRTUAL_REAL_IP_HEADER` | [`real_ip_header`](https://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header) | header name (e.g. `X-Forwarded-For`) |
+| `VIRTUAL_REAL_IP_RECURSIVE` | [`real_ip_recursive`](https://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive) | `on` or `off` |
+| `VIRTUAL_SEND_TIMEOUT` | [`send_timeout`](https://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout) | time |
+| `VIRTUAL_SET_REAL_IP_FROM` | [`set_real_ip_from`](https://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from) | IP address or CIDR (semicolon-separated for multiple values) |
+| `VIRTUAL_UNDERSCORES_IN_HEADERS` | [`underscores_in_headers`](https://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers) | `on` or `off` |
+
+> [!NOTE]
+> Global directives (proxy container) are placed in the nginx `http` block. Per-vhost directives (proxied container) are placed inside the `server` block of the respective virtual host.
+
+⬆️ [back to table of contents](#table-of-contents)
+
 ### Per-VIRTUAL_HOST
 
 To add settings on a per-`VIRTUAL_HOST` basis, add your configuration file under `/etc/nginx/vhost.d`. Unlike in the proxy-wide case, which allows multiple config files with any name ending in `.conf`, the per-`VIRTUAL_HOST` file must be named exactly after the `VIRTUAL_HOST`, or if `VIRTUAL_HOST` is a regex, after the sha1 hash of the regex.
@@ -1420,6 +1502,7 @@ Configuration available either on the nginx-proxy container, or the docker-gen c
 | [`DISABLE_ACCESS_LOGS`](#disable-access-logs) | `false` |
 | [`ENABLE_HTTP_ON_MISSING_CERT`](#default-and-missing-certificate) | `true` |
 | [`ENABLE_HTTP2`](#http2-support) | `true` |
+| [`ENABLE_VIRTUAL_CONFIG`](#virtual-nginx-directive-configuration-via-environment-variables) | `false` |
 | [`ENABLE_HTTP3`](#http3-support) | `false` |
 | [`ENABLE_IPV6`](#listening-on-ipv6) | `false` |
 | [`ENABLE_PROXY_PROTOCOL`](#proxy-protocol-support) | `false` |
@@ -1472,6 +1555,7 @@ Configuration available on each proxied container, either by environment variabl
 | [`SSL_POLICY`](#how-ssl-support-works) | n/a | global (proxy) value |
 | n/a | [`com.github.nginx-proxy.nginx-proxy.ssl_verify_client`](#optional-ssl_verify_client) | `on` |
 | n/a | [`com.github.nginx-proxy.nginx-proxy.trust-default-cert`](#default-and-missing-certificate) | global (proxy) value |
+| [`VIRTUAL_<DIRECTIVE>`](#virtual-nginx-directive-configuration-via-environment-variables) | n/a | no default value |
 | [`VIRTUAL_DEST`](#virtual_dest) | n/a | `empty string` |
 | [`VIRTUAL_HOST`](#virtual-hosts-and-ports) | n/a | no default value |
 | [`VIRTUAL_HOST_MULTIPORTS`](#multiple-ports) | n/a | no default value |

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -41,7 +41,47 @@
 {{- $_ := set $config "enable_json_logs" ($globals.Env.LOG_JSON | default "false" | parseBool) }}
 {{- $_ := set $config "log_format" $globals.Env.LOG_FORMAT }}
 {{- $_ := set $config "log_format_escape" $globals.Env.LOG_FORMAT_ESCAPE }}
-
+{{- $_ := set $config "enable_virtual_config" ($globals.Env.ENABLE_VIRTUAL_CONFIG | default "false" | parseBool) }}
+{{- $_ := set $config "regex_validation_size" "^[0-9]+[kmgKMG]?$" }}
+{{- $_ := set $config "regex_validation_time" "^[0-9]+(ms|[smhdwMy])?($|\\s+[0-9]+(ms|[smhdwMy])?)" }}
+{{- $_ := set $config "regex_validation_number_size" "^[0-9]+ [0-9]+[kmgKMG]?$" }}
+{{- $_ := set $config "regex_validation_number" "^[0-9]+$" }}
+{{- $_ := set $config "regex_validation_address" "^(unix:|[0-9A-Fa-f:.]+(/[0-9]{1,3})?)$" }}
+{{- $_ := set $config "regex_validation_identifier" "^[A-Za-z][A-Za-z0-9_-]*$" }}
+{{- $_ := set $config "regex_validation_on_off" "^(on|off)$" }}
+{{- $_ := set $config "available_virtual_config" (dict
+    "client_body_buffer_size" "regex_validation_size"
+    "client_body_timeout" "regex_validation_time"
+    "client_header_buffer_size" "regex_validation_size"
+    "client_header_timeout" "regex_validation_time"
+    "client_max_body_size" "regex_validation_size"
+    "keepalive_timeout" "regex_validation_time"
+    "large_client_header_buffers" "regex_validation_number_size"
+    "real_ip_header" "regex_validation_identifier"
+    "real_ip_recursive" "regex_validation_on_off"
+    "send_timeout" "regex_validation_time"
+    "proxy_buffer_size" "regex_validation_size"
+    "proxy_buffering" "regex_validation_on_off"
+    "proxy_buffers" "regex_validation_number_size"
+    "proxy_busy_buffers_size" "regex_validation_size"
+    "proxy_connect_timeout" "regex_validation_time"
+    "proxy_intercept_errors" "regex_validation_on_off"
+    "proxy_max_temp_file_size" "regex_validation_size"
+    "proxy_next_upstream_timeout" "regex_validation_time"
+    "proxy_next_upstream_tries" "regex_validation_number"
+    "proxy_read_timeout" "regex_validation_time"
+    "proxy_request_buffering" "regex_validation_on_off"
+    "proxy_ssl_server_name" "regex_validation_on_off"
+    "proxy_ssl_session_reuse" "regex_validation_on_off"
+    "proxy_ssl_verify" "regex_validation_on_off"
+    "proxy_ssl_verify_depth" "regex_validation_number"
+    "proxy_send_timeout" "regex_validation_time"
+    "proxy_temp_file_write_size" "regex_validation_size"
+    "set_real_ip_from" "regex_validation_address"
+    "ignore_invalid_headers" "regex_validation_on_off"
+    "underscores_in_headers" "regex_validation_on_off"
+    "keepalive_requests" "regex_validation_number"
+) }}
 {{- $_ := set $globals "config" $config }}
 
 {{- $_ := set $globals "vhosts" (dict) }}
@@ -598,6 +638,22 @@ proxy_set_header X-Original-URI $request_uri;
 proxy_set_header Proxy "";
 {{- end }}
 
+{{- if $config.enable_virtual_config }}
+    {{- range $key, $regex_validation_key := $config.available_virtual_config }}
+        {{- $env_key := printf "VIRTUAL_%s" (upper $key) }}
+        {{- $value := index $globals.Env $env_key | default "" }}
+        {{- $regex_validation := get $config $regex_validation_key | default "" }}
+        {{- if ne $value "" }}
+            {{- range $value_part := split $value ";" }}
+                {{- $value_part := trim $value_part }}
+                {{- if and (ne $value_part "") (or (eq $regex_validation "") (regexMatch $regex_validation $value_part)) }}
+{{ $key }} {{ $value_part }};
+                {{- end }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
 {{- /* Precompute and store some information about vhost that use VIRTUAL_HOST_MULTIPORTS. */}}
 {{- range $vhosts_yaml, $containers := groupBy $globals.containers "Env.VIRTUAL_HOST_MULTIPORTS" }}
     {{- /* Print a warning in the config if VIRTUAL_HOST_MULTIPORTS can't be parsed. */}}
@@ -701,6 +757,18 @@ proxy_set_header Proxy "";
     {{- if not (hasKey $vhost_data "external_https_port") }}
         {{- $_ := set $vhost_data "external_https_port" $external_https_port }}
     {{- end }}
+
+    {{- $vhost_virtual_config := dict }}
+    {{- if $config.enable_virtual_config }}
+        {{- range $key, $regex_validation_key := $config.available_virtual_config }}
+            {{- $env_path := printf "Env.VIRTUAL_%s" (upper $key) }}
+            {{- $value := groupByKeys $containers $env_path | first | default "" }}
+            {{- if ne $value "" }}
+                {{- $_ := set $vhost_virtual_config $key $value }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- $_ := set $vhost_data "virtual_config" $vhost_virtual_config }}
 
     {{- $tmp_paths := groupByWithDefault $containers "Env.VIRTUAL_PATH" "/" }}
 
@@ -1095,6 +1163,20 @@ server {
     include {{ printf "/etc/nginx/vhost.d/%s" (replace $vhostFileName "*" "\\*" -1) }};
     {{- else if (exists "/etc/nginx/vhost.d/default") }}
     include /etc/nginx/vhost.d/default;
+    {{- end }}
+
+    {{- range $key, $_ := $globals.config.available_virtual_config }}
+        {{- $value := get $vhost.virtual_config $key | default "" }}
+        {{- if ne $value "" }}
+            {{- $regex_validation_key := get $globals.config.available_virtual_config $key | default "" }}
+            {{- $regex_validation := get $globals.config $regex_validation_key | default "" }}
+            {{- range $value_part := split $value ";" }}
+                {{- $value_part := trim $value_part }}
+                {{- if and (ne $value_part "") (or (eq $regex_validation "") (regexMatch $regex_validation $value_part)) }}
+    {{ $key }} {{ $value_part }};
+                {{- end }}
+            {{- end }}
+        {{- end }}
     {{- end }}
 
     {{/* SSL Client Certificate Validation */}}

--- a/test/test_virtual-config/test_disabled.py
+++ b/test/test_virtual-config/test_disabled.py
@@ -1,0 +1,11 @@
+def test_virtual_config_disabled_by_default(docker_compose, nginxproxy):
+    """When ENABLE_VIRTUAL_CONFIG is not set, VIRTUAL_* directives should be ignored"""
+    r = nginxproxy.get("http://web.nginx-proxy.tld/")
+    assert r.status_code == 200
+    
+    # Check that the config was generated but virtual directives were not applied
+    config = nginxproxy.get_conf().decode('utf-8')
+    
+    # These directives should NOT appear in the http block since the feature is disabled
+    assert "client_max_body_size 50m;" not in config
+    assert "keepalive_timeout 60s;" not in config

--- a/test/test_virtual-config/test_disabled.yml
+++ b/test/test_virtual-config/test_disabled.yml
@@ -1,0 +1,14 @@
+services:
+  nginx-proxy:
+    environment:
+      # ENABLE_VIRTUAL_CONFIG not set, defaults to false
+      VIRTUAL_CLIENT_MAX_BODY_SIZE: "50m"
+
+  web:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: "80"
+      VIRTUAL_HOST: web.nginx-proxy.tld
+      VIRTUAL_KEEPALIVE_TIMEOUT: "60s"

--- a/test/test_virtual-config/test_global.py
+++ b/test/test_virtual-config/test_global.py
@@ -1,0 +1,11 @@
+def test_virtual_config_global_directives(docker_compose, nginxproxy):
+    """Global VIRTUAL_* directives should be rendered in http block"""
+    r = nginxproxy.get("http://web.nginx-proxy.tld/")
+    assert r.status_code == 200
+    
+    config = nginxproxy.get_conf().decode('utf-8')
+    
+    # Global directives in http block
+    assert "client_max_body_size 100m;" in config
+    assert "keepalive_timeout 120s;" in config
+    assert "keepalive_requests 500;" in config

--- a/test/test_virtual-config/test_global.yml
+++ b/test/test_virtual-config/test_global.yml
@@ -1,0 +1,15 @@
+services:
+  nginx-proxy:
+    environment:
+      ENABLE_VIRTUAL_CONFIG: "true"
+      VIRTUAL_CLIENT_MAX_BODY_SIZE: "100m"
+      VIRTUAL_KEEPALIVE_TIMEOUT: "120s"
+      VIRTUAL_KEEPALIVE_REQUESTS: "500"
+
+  web:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: "80"
+      VIRTUAL_HOST: web.nginx-proxy.tld

--- a/test/test_virtual-config/test_invalid_values.py
+++ b/test/test_virtual-config/test_invalid_values.py
@@ -1,0 +1,16 @@
+def test_virtual_config_invalid_values_ignored(docker_compose, nginxproxy):
+    """Invalid VIRTUAL_* values should be silently ignored due to format validation"""
+    r = nginxproxy.get("http://web.nginx-proxy.tld/")
+    assert r.status_code == 200
+    
+    config = nginxproxy.get_conf().decode('utf-8')
+    
+    # Valid value should be present
+    assert "client_max_body_size 100m;" in config
+    
+    # Invalid values should NOT appear (silently ignored)
+    assert "keepalive_timeout invalid_value;" not in config
+    assert "keepalive_requests not_a_number;" not in config
+    assert "proxy_buffering maybe;" not in config
+    assert "client_header_buffer_size not_a_size;" not in config
+    assert "real_ip_recursive yes_or_no;" not in config

--- a/test/test_virtual-config/test_invalid_values.yml
+++ b/test/test_virtual-config/test_invalid_values.yml
@@ -1,0 +1,21 @@
+services:
+  nginx-proxy:
+    environment:
+      ENABLE_VIRTUAL_CONFIG: "true"
+      # Valid directive
+      VIRTUAL_CLIENT_MAX_BODY_SIZE: "100m"
+      # Invalid values that should be silently ignored (format validation)
+      VIRTUAL_KEEPALIVE_TIMEOUT: "invalid_value"
+      VIRTUAL_KEEPALIVE_REQUESTS: "not_a_number"
+      VIRTUAL_PROXY_BUFFERING: "maybe"
+
+  web:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: "80"
+      VIRTUAL_HOST: web.nginx-proxy.tld
+      # Invalid per-vhost directives
+      VIRTUAL_CLIENT_HEADER_BUFFER_SIZE: "not_a_size"
+      VIRTUAL_REAL_IP_RECURSIVE: "yes_or_no"

--- a/test/test_virtual-config/test_multivalue_set_real_ip_from.py
+++ b/test/test_virtual-config/test_multivalue_set_real_ip_from.py
@@ -1,0 +1,27 @@
+def test_virtual_config_multivalue_set_real_ip_from_global(docker_compose, nginxproxy):
+    """Global VIRTUAL_SET_REAL_IP_FROM with semicolon-separated values should create multiple directives"""
+    r = nginxproxy.get("http://web.nginx-proxy.tld/")
+    assert r.status_code == 200
+    
+    config = nginxproxy.get_conf().decode('utf-8')
+    
+    # Each value should be a separate set_real_ip_from directive
+    assert "set_real_ip_from 10.0.0.0/8;" in config
+    assert "set_real_ip_from 172.16.0.0/12;" in config
+    assert "set_real_ip_from 192.168.0.0/16;" in config
+    
+    # Other real_ip directives should also be present
+    assert "real_ip_header X-Forwarded-For;" in config
+    assert "real_ip_recursive on;" in config
+
+
+def test_virtual_config_multivalue_set_real_ip_from_per_vhost(docker_compose, nginxproxy):
+    """Per-vhost VIRTUAL_SET_REAL_IP_FROM with semicolon-separated values"""
+    r = nginxproxy.get("http://web.nginx-proxy.tld/")
+    assert r.status_code == 200
+    
+    config = nginxproxy.get_conf().decode('utf-8')
+    
+    # Per-vhost directives should have separate set_real_ip_from lines
+    assert "set_real_ip_from 127.0.0.1;" in config
+    assert "set_real_ip_from ::1;" in config

--- a/test/test_virtual-config/test_multivalue_set_real_ip_from.yml
+++ b/test/test_virtual-config/test_multivalue_set_real_ip_from.yml
@@ -1,0 +1,18 @@
+services:
+  nginx-proxy:
+    environment:
+      ENABLE_VIRTUAL_CONFIG: "true"
+      # set_real_ip_from supports multiple addresses separated by semicolons
+      VIRTUAL_SET_REAL_IP_FROM: "10.0.0.0/8;172.16.0.0/12;192.168.0.0/16"
+      VIRTUAL_REAL_IP_HEADER: "X-Forwarded-For"
+      VIRTUAL_REAL_IP_RECURSIVE: "on"
+
+  web:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: "80"
+      VIRTUAL_HOST: web.nginx-proxy.tld
+      # Per-vhost multivalue directive
+      VIRTUAL_SET_REAL_IP_FROM: "127.0.0.1;::1"

--- a/test/test_virtual-config/test_per_vhost.py
+++ b/test/test_virtual-config/test_per_vhost.py
@@ -1,0 +1,11 @@
+def test_virtual_config_per_vhost_directives(docker_compose, nginxproxy):
+    """Per-vhost VIRTUAL_* directives should be rendered in server block"""
+    r = nginxproxy.get("http://web.nginx-proxy.tld/")
+    assert r.status_code == 200
+    
+    config = nginxproxy.get_conf().decode('utf-8')
+    
+    # Per-vhost directives in server block for web.nginx-proxy.tld
+    assert "client_max_body_size 200m;" in config
+    assert "keepalive_timeout 60s;" in config
+    assert "proxy_buffering off;" in config

--- a/test/test_virtual-config/test_per_vhost.yml
+++ b/test/test_virtual-config/test_per_vhost.yml
@@ -1,0 +1,15 @@
+services:
+  nginx-proxy:
+    environment:
+      ENABLE_VIRTUAL_CONFIG: "true"
+
+  web:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: "80"
+      VIRTUAL_HOST: web.nginx-proxy.tld
+      VIRTUAL_CLIENT_MAX_BODY_SIZE: "200m"
+      VIRTUAL_KEEPALIVE_TIMEOUT: "60s"
+      VIRTUAL_PROXY_BUFFERING: "off"


### PR DESCRIPTION
### Feature Overview
Enable dynamic nginx directive configuration through environment variables without needing custom conf files.

- **Feature Flag**: `ENABLE_VIRTUAL_CONFIG=true` on nginx-proxy container to activate
- **Global Directives**: Set via `VIRTUAL_<DIRECTIVE>` on nginx-proxy container (rendered in http block)
- **Per-Vhost Directives**: Set via `VIRTUAL_<DIRECTIVE>` on proxied containers (rendered in server block)
- **Multi-Value Support**: Semicolon-separated values (e.g., `VIRTUAL_SET_REAL_IP_FROM=10.0.0.0/8;172.16.0.0/12`)
- **Format Validation**: Regex-based validation for each directive type

### Supported Directives (31 total)
**Real IP**: set_real_ip_from, real_ip_header, real_ip_recursive
**Buffer Management**: client_body_buffer_size, client_header_buffer_size, client_max_body_size
**Timeouts**: keepalive_timeout, proxy_connect_timeout, proxy_send_timeout, proxy_read_timeout
**Request Handling**: proxy_buffering, proxy_request_buffering, proxy_intercept_errors
**And 18 more** (see docs for complete reference)

### Implementation Details
- **nginx.tmpl**: Added virtual config rendering logic with format validators
- **Regex Validators**: 7 patterns (size, time, number, number_size, address, identifier, on_off)
- **Behavior**: Invalid values are silently ignored via format validation

### Testing
Created comprehensive test suite in `test/test_virtual-config/`:

| Test | Purpose |
|------|---------|
| test_disabled | Verify VIRTUAL_* ignored when feature disabled |
| test_global | Validate global directives render in http block |
| test_per_vhost | Validate per-vhost directives render in server block |
| test_invalid_values | Confirm format validation rejects invalid values |
| test_multivalue_set_real_ip_from | Verify semicolon-separated multi-value directives |

**Test Results**: ✅ 6/6 passed

### Usage Example

**Global configuration**:
```yaml
nginx-proxy:
  image: nginxproxy/nginx-proxy
  environment:
    ENABLE_VIRTUAL_CONFIG: "true"
    VIRTUAL_CLIENT_MAX_BODY_SIZE: "100m"
    VIRTUAL_KEEPALIVE_TIMEOUT: "120s"
    VIRTUAL_SET_REAL_IP_FROM: "10.0.0.0/8;172.16.0.0/12"
```

**Per-vhost configuration**:
```yaml
app:
  environment:
    VIRTUAL_HOST: app.example.com
    VIRTUAL_CLIENT_MAX_BODY_SIZE: "200m"
    VIRTUAL_PROXY_BUFFERING: "off"
```

### Documentation
Updated `docs/README.md` with:
- Feature overview and configuration guide
- Complete directive reference table with nginx docs links
- Format validation requirements for each directive type
- Usage examples for global and per-vhost scenarios
