### PR TITLE
chore: improve nginx-proxy maintenance path

### DIFF
--- a/test/test_ipv6/test_ipv6.py
+++ b/test/test_ipv6/test_ipv6.py
@@ -15,14 +15,14 @@ def test_unknown_virtual_host_ipv4(docker_compose, nginxproxy):
 
 def test_forwards_to_web1_ipv4(docker_compose, nginxproxy):
     r = nginxproxy.get("http://web1.nginx-proxy.tld/port")
-    assert r.status_code == 200   
+    assert r.status_code == 200
     assert r.text == "answer from port 81\n"
 
 
 def test_forwards_to_web2_ipv4(docker_compose, nginxproxy):
     r = nginxproxy.get("http://web2.nginx-proxy.tld/port")
     assert r.status_code == 200
-    assert r.text == "answer from port 82\n" 
+    assert r.text == "answer from port 82\n"
 
 
 def test_unknown_virtual_host_ipv6(docker_compose, nginxproxy):
@@ -32,11 +32,11 @@ def test_unknown_virtual_host_ipv6(docker_compose, nginxproxy):
 
 def test_forwards_to_web1_ipv6(docker_compose, nginxproxy):
     r = nginxproxy.get("http://web1.nginx-proxy.tld/port", ipv6=True)
-    assert r.status_code == 200   
+    assert r.status_code == 200
     assert r.text == "answer from port 81\n"
 
 
 def test_forwards_to_web2_ipv6(docker_compose, nginxproxy):
     r = nginxproxy.get("http://web2.nginx-proxy.tld/port", ipv6=True)
     assert r.status_code == 200
-    assert r.text == "answer from port 82\n" 
+    assert r.text == "answer from port 82\n"

--- a/test/test_ssl/test_hsts.py
+++ b/test/test_ssl/test_hsts.py
@@ -2,6 +2,7 @@ def test_web1_HSTS_default(docker_compose, nginxproxy):
     r = nginxproxy.get("https://web1.nginx-proxy.tld/port", allow_redirects=False)
     assert "answer from port 81\n" in r.text
     assert "Strict-Transport-Security" in r.headers
+    assert isinstance(r.headers["Strict-Transport-Security"], str)
     assert "max-age=31536000" == r.headers["Strict-Transport-Security"]
 
 # Regression test to ensure HSTS is enabled even when the upstream sends an error in response
@@ -9,6 +10,7 @@ def test_web1_HSTS_default(docker_compose, nginxproxy):
 def test_web1_HSTS_error(docker_compose, nginxproxy):
     r = nginxproxy.get("https://web1.nginx-proxy.tld/status/500", allow_redirects=False)
     assert "Strict-Transport-Security" in r.headers
+    assert isinstance(r.headers["Strict-Transport-Security"], str)
     assert "max-age=31536000" == r.headers["Strict-Transport-Security"]
 
 def test_web2_HSTS_off(docker_compose, nginxproxy):
@@ -20,6 +22,7 @@ def test_web3_HSTS_custom(docker_compose, nginxproxy):
     r = nginxproxy.get("https://web3.nginx-proxy.tld/port", allow_redirects=False)
     assert "answer from port 81\n" in r.text
     assert "Strict-Transport-Security" in r.headers
+    assert isinstance(r.headers["Strict-Transport-Security"], str)
     assert "max-age=86400; includeSubDomains; preload" == r.headers["Strict-Transport-Security"]
 
 # Regression test for issue 1080
@@ -33,6 +36,8 @@ def test_http3_vhost_enabled_HSTS_default(docker_compose, nginxproxy):
     r = nginxproxy.get("https://http3-vhost-enabled.nginx-proxy.tld/port", allow_redirects=False)
     assert "answer from port 81\n" in r.text
     assert "Strict-Transport-Security" in r.headers
+    assert isinstance(r.headers["Strict-Transport-Security"], str)
     assert "max-age=31536000" == r.headers["Strict-Transport-Security"]
     assert "alt-svc" in r.headers
+    assert isinstance(r.headers["alt-svc"], str)
     assert r.headers["alt-svc"] == 'h3=":443"; ma=86400;'


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in test/test_ssl/test_hsts.py, test/test_ipv6/test_ipv6.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.