### PR TITLE
fix: respect user-provided RESOLVERS environment variable

### DIFF
--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -53,6 +53,13 @@ function _check_unix_socket() {
 }
 
 function _resolvers() {
+	# Honor a user-provided RESOLVERS value and only autodetect the DNS resolvers
+	# from /etc/resolv.conf when it has not been set (see issue #2699).
+	if [[ -n ${RESOLVERS:-} ]]; then
+		export RESOLVERS
+		return
+	fi
+
 	# Compute the DNS resolvers for use in the templates - if the IP contains ":", it's IPv6 and must be enclosed in []
 	RESOLVERS=$(awk '$1 == "nameserver" {print ($2 ~ ":")? "["$2"]": $2}' ORS=' ' /etc/resolv.conf | sed 's/ *$//g'); export RESOLVERS
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -801,6 +801,20 @@ docker run --detach \
     nginxproxy/nginx-proxy
 ```
 
+### Custom DNS Resolvers
+
+nginx needs DNS resolvers to resolve names at runtime (for example for OCSP stapling). By default, nginx-proxy autodetects them from the proxy container's `/etc/resolv.conf` (typically Docker's embedded DNS server, e.g. `127.0.0.11`).
+
+You can override the autodetection by setting the `RESOLVERS` environment variable on the proxy container to a space-separated list of DNS servers. When `RESOLVERS` is set, its value is used as-is and the autodetection is skipped:
+
+```console
+docker run --detach \
+    --publish 80:80 \
+    --env RESOLVERS=8.8.8.8 \
+    --volume /var/run/docker.sock:/tmp/docker.sock:ro \
+    nginxproxy/nginx-proxy
+```
+
 ### Scoped IPv6 Resolvers
 
 Nginx does not support scoped IPv6 resolvers. In [docker-entrypoint.sh](https://github.com/nginx-proxy/nginx-proxy/blob/main/app/docker-entrypoint.sh) the resolvers are parsed from resolv.conf, but any scoped IPv6 addreses will be removed.
@@ -1433,7 +1447,7 @@ Configuration available either on the nginx-proxy container, or the docker-gen c
 | [`NGINX_CONTAINER_LABEL`](#network-segregation) | `com.github.nginx-proxy.nginx-proxy.nginx` |
 | [`NON_GET_REDIRECT`](#how-ssl-support-works) | `301` |
 | [`PREFER_IPV6_NETWORK`](#ipv6-docker-networks) | `false` |
-| `RESOLVERS` | no default value |
+| [`RESOLVERS`](#custom-dns-resolvers) | no default value |
 | [`SHA1_UPSTREAM_NAME`](#unhashed-vs-sha1-upstream-names) | `false` |
 | [`SSL_POLICY`](#how-ssl-support-works) | `Mozilla-Intermediate` |
 | [`TRUST_DEFAULT_CERT`](#default-and-missing-certificate) | `true` |

--- a/test/test_resolvers/test_resolvers.base.yml
+++ b/test/test_resolvers/test_resolvers.base.yml
@@ -1,0 +1,17 @@
+services:
+  # Proxy with a user-provided RESOLVERS value: it must be honored as-is.
+  resolvers-custom:
+    image: nginxproxy/nginx-proxy:test
+    container_name: resolvers-custom
+    environment:
+      RESOLVERS: 8.8.8.8
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+
+  # Proxy without RESOLVERS: the entrypoint must autodetect from /etc/resolv.conf
+  # (Docker's embedded DNS server, 127.0.0.11, on a user-defined network).
+  resolvers-auto:
+    image: nginxproxy/nginx-proxy:test
+    container_name: resolvers-auto
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro

--- a/test/test_resolvers/test_resolvers.py
+++ b/test/test_resolvers/test_resolvers.py
@@ -1,0 +1,26 @@
+import docker
+
+docker_client = docker.from_env()
+
+
+def _generated_config(container_name: str) -> str:
+    sut_container = docker_client.containers.get(container_name)
+    assert sut_container.status == "running"
+    exit_code, output = sut_container.exec_run("cat /etc/nginx/conf.d/default.conf")
+    assert exit_code == 0, output.decode()
+    return output.decode()
+
+
+# Regression test for https://github.com/nginx-proxy/nginx-proxy/issues/2699:
+# a user-provided RESOLVERS value must be honored and not overwritten by the
+# entrypoint's autodetection from /etc/resolv.conf.
+def test_user_provided_resolvers_is_honored(docker_compose):
+    config = _generated_config("resolvers-custom")
+    assert "resolver 8.8.8.8;" in config
+
+
+# When RESOLVERS is not set, the entrypoint should still autodetect the resolvers
+# from /etc/resolv.conf (Docker's embedded DNS on a user-defined network).
+def test_resolvers_are_autodetected_when_unset(docker_compose):
+    config = _generated_config("resolvers-auto")
+    assert "resolver 127.0.0.11;" in config


### PR DESCRIPTION
## What this does

`RESOLVERS` is documented as a configurable environment variable (listed with "no default value" in the configuration summary), implying users can point nginx at custom DNS resolvers. However, the entrypoint's `_resolvers()` always recomputed `RESOLVERS` from `/etc/resolv.conf` and exported it, silently overwriting any value set by the user. This is the bug reported in #2699.

## Fix

`_resolvers()` now honors a user-provided `RESOLVERS` value and only autodetects from `/etc/resolv.conf` when it is unset/empty. The existing autodetection logic (including scoped-IPv6 stripping and the "unable to determine resolvers" warning) is left unchanged.

```bash
function _resolvers() {
	# Honor a user-provided RESOLVERS value and only autodetect the DNS resolvers
	# from /etc/resolv.conf when it has not been set (see issue #2699).
	if [[ -n ${RESOLVERS:-} ]]; then
		export RESOLVERS
		return
	fi
	# ... unchanged autodetection ...
}
```

## Docs

Adds a "Custom DNS Resolvers" section explaining the autodetection and how to override it with `RESOLVERS`, and links the configuration-summary entry to it.

## Tests

Adds `test/test_resolvers/` covering both behaviors:

- a user-provided `RESOLVERS=8.8.8.8` appears as `resolver 8.8.8.8;` in the generated config (the regression);
- with `RESOLVERS` unset, the resolver is still autodetected (`127.0.0.11` on a user-defined Docker network).

Verified locally: the new integration tests pass against a `nginxproxy/nginx-proxy:test` image built from this branch, and `shellcheck` reports no findings on `app/docker-entrypoint.sh`.

Closes #2699

🤖 Generated with [Claude Code](https://claude.com/claude-code)
