### PR TITLE
feat: add VIRTUAL_INDEX support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -374,6 +374,14 @@ If you would like to connect to FastCGI backend, set `VIRTUAL_PROTO=fastcgi` on 
 
 If you use fastcgi,you can set `VIRTUAL_ROOT=xxx` for your root directory
 
+#### FastCGI Index File
+
+If you use fastcgi, you can set `VIRTUAL_INDEX=index.php` to define the index file nginx
+serves when a directory is requested (it sets the nginx [`index`](https://nginx.org/en/docs/http/ngx_http_index_module.html#index)
+directive inside the location block). Multiple space-separated file names are allowed, e.g.
+`VIRTUAL_INDEX=index.php index.html`. This setting only has an effect for FastCGI backends
+(it is paired with `VIRTUAL_ROOT`); for `proxy_pass`/uwsgi/grpc upstreams it has no effect.
+
 ### Upstream Server HTTP Load Balancing Support
 
 If you have multiple containers with the same `VIRTUAL_HOST` and `VIRTUAL_PATH` settings, nginx will spread the load across all of them. To change the load balancing algorithm from nginx's default (round-robin), set the `com.github.nginx-proxy.nginx-proxy.loadbalance` label on one or more of your application containers to the desired load balancing directive. See the [`ngx_http_upstream_module` documentation](https://nginx.org/en/docs/http/ngx_http_upstream_module.html) for available directives.
@@ -1489,6 +1497,7 @@ Configuration available on each proxied container, either by environment variabl
 | [`VIRTUAL_DEST`](#virtual_dest) | n/a | `empty string` |
 | [`VIRTUAL_HOST`](#virtual-hosts-and-ports) | n/a | no default value |
 | [`VIRTUAL_HOST_MULTIPORTS`](#multiple-ports) | n/a | no default value |
+| [`VIRTUAL_INDEX`](#fastcgi-index-file) | n/a | `empty string` |
 | [`VIRTUAL_PATH`](#path-based-routing) | n/a | `/` |
 | [`VIRTUAL_PORT`](#virtual-ports) | n/a | no default value |
 | [`VIRTUAL_PROTO`](#upstream-backend-features) | n/a | `http` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -374,6 +374,14 @@ If you would like to connect to FastCGI backend, set `VIRTUAL_PROTO=fastcgi` on 
 
 If you use fastcgi,you can set `VIRTUAL_ROOT=xxx` for your root directory
 
+#### FastCGI Index File
+
+If you use fastcgi, you can set `VIRTUAL_INDEX=index.php` to define the index file nginx
+serves when a directory is requested (it sets the nginx [`index`](https://nginx.org/en/docs/http/ngx_http_index_module.html#index)
+directive inside the location block). Multiple space-separated file names are allowed, e.g.
+`VIRTUAL_INDEX=index.php index.html`. This setting only has an effect for FastCGI backends
+(it is paired with `VIRTUAL_ROOT`); for `proxy_pass`/uwsgi/grpc upstreams it has no effect.
+
 ### Upstream Server HTTP Load Balancing Support
 
 If you have multiple containers with the same `VIRTUAL_HOST` and `VIRTUAL_PATH` settings, nginx will spread the load across all of them. To change the load balancing algorithm from nginx's default (round-robin), set the `com.github.nginx-proxy.nginx-proxy.loadbalance` label on one or more of your application containers to the desired load balancing directive. See the [`ngx_http_upstream_module` documentation](https://nginx.org/en/docs/http/ngx_http_upstream_module.html) for available directives.
@@ -1503,6 +1511,7 @@ Configuration available on each proxied container, either by environment variabl
 | [`VIRTUAL_DEST`](#virtual_dest) | n/a | `empty string` |
 | [`VIRTUAL_HOST`](#virtual-hosts-and-ports) | n/a | no default value |
 | [`VIRTUAL_HOST_MULTIPORTS`](#multiple-ports) | n/a | no default value |
+| [`VIRTUAL_INDEX`](#fastcgi-index-file) | n/a | `empty string` |
 | [`VIRTUAL_PATH`](#path-based-routing) | n/a | `/` |
 | [`VIRTUAL_PORT`](#virtual-ports) | n/a | no default value |
 | [`VIRTUAL_PROTO`](#upstream-backend-features) | n/a | `http` |

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -315,6 +315,9 @@
         # neither /etc/nginx/fastcgi.conf nor /etc/nginx/fastcgi_params found, fastcgi won't work
             {{- end }}
         root {{ trim .VhostRoot }};
+            {{- if $vpath.index }}
+        index {{ $vpath.index }};
+            {{- end }}
         fastcgi_pass {{ trim $upstream }};
             {{- if ne $keepalive "disabled" }}
         fastcgi_keep_conn on;
@@ -707,6 +710,7 @@ proxy_set_header Proxy "";
     {{- range $path, $containers := $tmp_paths }}
         {{- $dest := groupByKeys $containers "Env.VIRTUAL_DEST" | first | default "" }}
         {{- $proto := groupByKeys $containers "Env.VIRTUAL_PROTO" | first | default "http" | trim }}
+        {{- $index := groupByKeys $containers "Env.VIRTUAL_INDEX" | first | default "" | trim }}
 
         {{- $path_data := get $paths $path | default (dict) }}
         {{- $path_ports := $path_data.ports | default (dict) }}
@@ -722,6 +726,10 @@ proxy_set_header Proxy "";
 
         {{- if (not (hasKey $path_data "proto")) }}
             {{- $_ := set $path_data "proto" $proto }}
+        {{- end }}
+
+        {{- if (not (hasKey $path_data "index")) }}
+            {{- $_ := set $path_data "index" $index }}
         {{- end }}
 
         {{- $_ := set $paths $path $path_data }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -316,6 +316,9 @@
         # neither /etc/nginx/fastcgi.conf nor /etc/nginx/fastcgi_params found, fastcgi won't work
             {{- end }}
         root {{ trim .VhostRoot }};
+            {{- if $vpath.index }}
+        index {{ $vpath.index }};
+            {{- end }}
         fastcgi_pass {{ trim $upstream }};
             {{- if ne $keepalive "disabled" }}
         fastcgi_keep_conn on;
@@ -708,6 +711,7 @@ proxy_set_header Proxy "";
     {{- range $path, $containers := $tmp_paths }}
         {{- $dest := groupByKeys $containers "Env.VIRTUAL_DEST" | first | default "" }}
         {{- $proto := groupByKeys $containers "Env.VIRTUAL_PROTO" | first | default "http" | trim }}
+        {{- $index := groupByKeys $containers "Env.VIRTUAL_INDEX" | first | default "" | trim }}
 
         {{- $path_data := get $paths $path | default (dict) }}
         {{- $path_ports := $path_data.ports | default (dict) }}
@@ -723,6 +727,10 @@ proxy_set_header Proxy "";
 
         {{- if (not (hasKey $path_data "proto")) }}
             {{- $_ := set $path_data "proto" $proto }}
+        {{- end }}
+
+        {{- if (not (hasKey $path_data "index")) }}
+            {{- $_ := set $path_data "index" $index }}
         {{- end }}
 
         {{- $_ := set $paths $path $path_data }}

--- a/test/test_virtual-index/test_virtual-index.py
+++ b/test/test_virtual-index/test_virtual-index.py
@@ -1,0 +1,29 @@
+import re
+
+
+def _server_block(conf: str, server_name: str) -> str:
+    """Return the text of the server { } block whose server_name matches."""
+    idx = conf.index(f"server_name {server_name};")
+    start = conf.rindex("server {", 0, idx)
+    depth = 0
+    for i in range(start, len(conf)):
+        if conf[i] == "{":
+            depth += 1
+        elif conf[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return conf[start:i + 1]
+    return conf[start:]
+
+
+def test_virtual_index_directive_present_when_set(docker_compose, nginxproxy):
+    conf = nginxproxy.get_conf().decode("ASCII")
+    block = _server_block(conf, "index-set.nginx-proxy.tld")
+    assert "index index.php;" in block
+
+
+def test_virtual_index_directive_absent_when_unset(docker_compose, nginxproxy):
+    conf = nginxproxy.get_conf().decode("ASCII")
+    block = _server_block(conf, "index-unset.nginx-proxy.tld")
+    # No bare `index` directive should be emitted (avoid matching `fastcgi_index`, etc.)
+    assert re.search(r"^\s*index\s", block, re.MULTILINE) is None

--- a/test/test_virtual-index/test_virtual-index.yml
+++ b/test/test_virtual-index/test_virtual-index.yml
@@ -1,0 +1,21 @@
+services:
+  index-set:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: "80"
+      VIRTUAL_HOST: index-set.nginx-proxy.tld
+      VIRTUAL_PROTO: fastcgi
+      VIRTUAL_ROOT: /var/www/public
+      VIRTUAL_INDEX: index.php
+
+  index-unset:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: "80"
+      VIRTUAL_HOST: index-unset.nginx-proxy.tld
+      VIRTUAL_PROTO: fastcgi
+      VIRTUAL_ROOT: /var/www/public


### PR DESCRIPTION
## What this does

Adds a `VIRTUAL_INDEX` environment variable for proxied containers, letting users set the nginx [`index`](https://nginx.org/en/docs/http/ngx_http_index_module.html#index) directive (the file served when a directory is requested, e.g. `index.php`). Resolves #1117.

## Implementation

`VIRTUAL_INDEX` is read per `VIRTUAL_PATH`, alongside `VIRTUAL_PROTO`/`VIRTUAL_DEST`, and emitted as `index <value>;` inside the generated **FastCGI** location block, right after `root` (i.e. paired with `VIRTUAL_ROOT`).

The nginx `index` directive only takes effect when nginx serves files from disk, which in this template is the fastcgi branch; for `proxy_pass`/uwsgi/grpc it would be a no-op, so it is intentionally not emitted there. Multiple space-separated files are supported (`VIRTUAL_INDEX=index.php index.html`); the value is emitted verbatim, consistent with the existing trust model for `VIRTUAL_ROOT`/`VIRTUAL_DEST`.

## Docs & tests

- Adds a "FastCGI Index File" docs section and a `VIRTUAL_INDEX` row to the proxied-container configuration summary.
- Adds `test/test_virtual-index/` asserting the `index` directive is present in the generated config when `VIRTUAL_INDEX` is set, and absent when it is not.

Verified locally: the new integration test passes against a `nginxproxy/nginx-proxy:test` image built from this branch.

## Relation to #1118

This supersedes #1118, which proposed the same feature but predates the current `nginx.tmpl` (where its patch no longer applies) and lacked tests/docs. This PR adapts the idea to the current template, scopes the directive to where it actually has an effect, and adds coverage.

Closes #1117
Supersedes #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)
