### PR TITLE
feat: add X_ROBOTS_TAG support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1206,6 +1206,10 @@ location / {
 
 Per virtual-host `servers_tokens` directive can be configured by passing appropriate value to the `SERVER_TOKENS` environment variable. Please see the [nginx http_core module configuration](https://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens) for more details.
 
+### Per-VIRTUAL_HOST `X-Robots-Tag` configuration
+
+Set the `X_ROBOTS_TAG` environment variable on a proxied container to add an [`X-Robots-Tag`](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#xrobotstag) response header to every response for that virtual host. This is useful for keeping staging sites out of search engines, e.g. `X_ROBOTS_TAG="noindex, nofollow"`. The value is emitted verbatim with the `always` flag so it is also sent on error responses.
+
 ### Custom error page
 
 To override the default error page displayed on 50x errors, mount your custom HTML error page inside the container at `/usr/share/nginx/html/errors/50x.html`:
@@ -1507,6 +1511,7 @@ Configuration available on each proxied container, either by environment variabl
 | [`VIRTUAL_PORT`](#virtual-ports) | n/a | no default value |
 | [`VIRTUAL_PROTO`](#upstream-backend-features) | n/a | `http` |
 | [`VIRTUAL_ROOT`](#fastcgi-file-root-directory) | n/a | `/var/www/public` |
+| [`X_ROBOTS_TAG`](#per-virtual_host-x-robots-tag-configuration) | n/a | no default value |
 
 ### Configuration by files
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -814,6 +814,9 @@ proxy_set_header Proxy "";
     {{- /* Get the SERVER_TOKENS defined by containers w/ the same vhost, falling back to "". */}}
     {{- $server_tokens := groupByKeys $vhost_containers "Env.SERVER_TOKENS" | first | default "" | trim }}
 
+    {{- /* Get the X_ROBOTS_TAG defined by containers w/ the same vhost, falling back to "". */}}
+    {{- $x_robots_tag := groupByKeys $vhost_containers "Env.X_ROBOTS_TAG" | first | default "" | trim }}
+
     {{- /* Get the SSL_POLICY defined by containers w/ the same vhost, falling back to empty string (use default). */}}
     {{- $ssl_policy := groupByKeys $vhost_containers "Env.SSL_POLICY" | first | default "" }}
 
@@ -841,6 +844,7 @@ proxy_set_header Proxy "";
         "acme_http_challenge_legacy" $acme_http_challenge_legacy
         "acme_http_challenge_enabled" $acme_http_challenge_enabled
         "server_tokens" $server_tokens
+        "x_robots_tag" $x_robots_tag
         "ssl_policy" $ssl_policy
         "ssl_verify_client" $ssl_verify_client
         "trust_default_cert" $trust_default_cert
@@ -966,6 +970,9 @@ server {
         {{- if $vhost.server_tokens }}
     server_tokens {{ $vhost.server_tokens }};
         {{- end }}
+        {{- if $vhost.x_robots_tag }}
+    add_header X-Robots-Tag "{{ $vhost.x_robots_tag }}" always;
+        {{- end }}
     {{ template "access_log" (dict "Enable" $globals.config.enable_access_log) }}
         {{- if $vhost.http2_enabled }}
     http2 on;
@@ -1027,6 +1034,9 @@ server {
     server_name {{ $hostname }};
     {{- if $vhost.server_tokens }}
     server_tokens {{ $vhost.server_tokens }};
+    {{- end }}
+    {{- if $vhost.x_robots_tag }}
+    add_header X-Robots-Tag "{{ $vhost.x_robots_tag }}" always;
     {{- end }}
     {{ template "access_log" (dict "Enable" $globals.config.enable_access_log) }}
     {{- if $vhost.http2_enabled }}

--- a/test/test_x-robots-tag/test_x-robots-tag.py
+++ b/test/test_x-robots-tag/test_x-robots-tag.py
@@ -1,0 +1,42 @@
+def _server_blocks(conf: str, server_name: str) -> list:
+    """Return every server { } block whose server_name matches.
+
+    A vhost can produce more than one server block (e.g. an HTTP redirect
+    server plus the main server), so all matching blocks are collected.
+    """
+    blocks = []
+    needle = f"server_name {server_name};"
+    pos = 0
+    while True:
+        idx = conf.find(needle, pos)
+        if idx == -1:
+            break
+        start = conf.rindex("server {", 0, idx)
+        depth = 0
+        end = len(conf)
+        for i in range(start, len(conf)):
+            if conf[i] == "{":
+                depth += 1
+            elif conf[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        blocks.append(conf[start:end])
+        pos = end
+    return blocks
+
+
+def test_x_robots_tag_header_present_when_set(docker_compose, nginxproxy):
+    conf = nginxproxy.get_conf().decode("ASCII")
+    blocks = _server_blocks(conf, "robots-set.nginx-proxy.tld")
+    assert blocks, "no server block found for robots-set.nginx-proxy.tld"
+    # The directive must be present in every server block of the vhost.
+    assert all('add_header X-Robots-Tag "noindex, nofollow" always;' in b for b in blocks)
+
+
+def test_x_robots_tag_header_absent_when_unset(docker_compose, nginxproxy):
+    conf = nginxproxy.get_conf().decode("ASCII")
+    blocks = _server_blocks(conf, "robots-unset.nginx-proxy.tld")
+    assert blocks, "no server block found for robots-unset.nginx-proxy.tld"
+    assert all("X-Robots-Tag" not in b for b in blocks)

--- a/test/test_x-robots-tag/test_x-robots-tag.yml
+++ b/test/test_x-robots-tag/test_x-robots-tag.yml
@@ -1,0 +1,17 @@
+services:
+  robots-set:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: "80"
+      VIRTUAL_HOST: robots-set.nginx-proxy.tld
+      X_ROBOTS_TAG: "noindex, nofollow"
+
+  robots-unset:
+    image: web
+    expose:
+      - "80"
+    environment:
+      WEB_PORTS: "80"
+      VIRTUAL_HOST: robots-unset.nginx-proxy.tld


### PR DESCRIPTION
## What this does

Adds an `X_ROBOTS_TAG` environment variable for proxied containers. When set, nginx-proxy emits an [`X-Robots-Tag`](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#xrobotstag) response header for that virtual host, e.g. `X_ROBOTS_TAG="noindex, nofollow"`. This is the common ask for keeping staging environments out of search engines. Resolves #1125.

## Implementation

`X_ROBOTS_TAG` is read per virtual host alongside `SERVER_TOKENS` (`groupByKeys $vhost_containers "Env.X_ROBOTS_TAG"`), stored on the vhost struct, and emitted as:

```nginx
add_header X-Robots-Tag "<value>" always;
```

It is placed at **server** scope (so it is inherited by all of the vhost's locations — the location template defines no `add_header` of its own), in both the redirect and the main `server` block, mirroring how `server_tokens` is handled. The value is emitted verbatim inside quotes (so multi-token values like `noindex, nofollow` work), consistent with the existing trust model for `SERVER_TOKENS`/`HSTS`/`VIRTUAL_*`. `always` ensures the header is sent on error responses too. When unset, nothing is emitted.

## Docs & tests

- Adds a "Per-VIRTUAL_HOST `X-Robots-Tag` configuration" section and an `X_ROBOTS_TAG` row to the proxied-container configuration summary.
- Adds `test/test_x-robots-tag/` asserting the `add_header X-Robots-Tag ...` directive is present in the generated config for a vhost with `X_ROBOTS_TAG` set, and absent for one without it.

Verified locally: the new integration test passes against a `nginxproxy/nginx-proxy:test` image built from this branch.

Closes #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
