### PR TITLE
feat: include vhost.d in the redirect server block

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -997,6 +997,8 @@ To add settings on a per-`VIRTUAL_HOST` basis, add your configuration file under
 
 In order to allow virtual hosts to be dynamically configured as backends are added and removed, it makes the most sense to mount an external directory as `/etc/nginx/vhost.d` as opposed to using derived images or mounting individual configuration files.
 
+These files are also included in the HTTP server block that performs the HTTPS redirect (when `HTTPS_METHOD=redirect`), so you can apply custom configuration (such as response headers) to the redirect responses as well, not just to the main HTTPS server block.
+
 For example, if you have a virtual host named `app.example.com`, you could provide a custom configuration for that host as follows:
 
 1. create your virtual host config file:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1001,6 +1001,8 @@ To add settings on a per-`VIRTUAL_HOST` basis, add your configuration file under
 
 In order to allow virtual hosts to be dynamically configured as backends are added and removed, it makes the most sense to mount an external directory as `/etc/nginx/vhost.d` as opposed to using derived images or mounting individual configuration files.
 
+These files are also included in the HTTP server block that performs the HTTPS redirect (when `HTTPS_METHOD=redirect`), so you can apply custom configuration (such as response headers) to the redirect responses as well, not just to the main HTTPS server block.
+
 For example, if you have a virtual host named `app.example.com`, you could provide a custom configuration for that host as follows:
 
 1. create your virtual host config file:

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -948,6 +948,7 @@ server {
 {{- range $hostname, $vhost := $globals.vhosts }}
     {{- $default_server := when $vhost.default " default_server" "" }}
     {{- $proxy_protocol := when $globals.config.enable_proxy_protocol " proxy_protocol" "" }}
+    {{- $vhostFileName := $vhost.is_regexp | ternary (sha1 $hostname) $hostname }}
 
     {{- range $path, $vpath := $vhost.paths }}
 # {{ $hostname }}{{ $path }}
@@ -981,6 +982,12 @@ server {
     }
         {{- end }}
 
+        {{- if (exists (printf "/etc/nginx/vhost.d/%s" $vhostFileName)) }}
+    include {{ printf "/etc/nginx/vhost.d/%s" (replace $vhostFileName "*" "\\*" -1) }};
+        {{- else if (exists "/etc/nginx/vhost.d/default") }}
+    include /etc/nginx/vhost.d/default;
+        {{- end }}
+
         {{- if $vhost.enable_debug_endpoint }}
             {{ template "debug_location" (dict "GlobalConfig" $globals.config "Hostname" $hostname "VHost" $vhost) }}
         {{- end }}
@@ -995,6 +1002,13 @@ server {
             return {{ $vhost.non_get_redirect }} {{ $redirect_uri }};
         }
         {{- end}}
+
+        {{- if (exists (printf "/etc/nginx/vhost.d/%s_location" $vhostFileName)) }}
+        include {{ printf "/etc/nginx/vhost.d/%s_location" (replace $vhostFileName "*" "\\*" -1) }};
+        {{- else if (exists "/etc/nginx/vhost.d/default_location") }}
+        include /etc/nginx/vhost.d/default_location;
+        {{- end }}
+
         return 301 {{ $redirect_uri }};
     }
 }
@@ -1093,8 +1107,6 @@ server {
     ssl_reject_handshake on;
         {{- end }}
     {{- end }}
-
-    {{- $vhostFileName :=  $vhost.is_regexp | ternary (sha1 $hostname) $hostname }}
 
     {{- if (exists (printf "/etc/nginx/vhost.d/%s" $vhostFileName)) }}
     include {{ printf "/etc/nginx/vhost.d/%s" (replace $vhostFileName "*" "\\*" -1) }};

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -954,6 +954,7 @@ server {
 {{- range $hostname, $vhost := $globals.vhosts }}
     {{- $default_server := when $vhost.default " default_server" "" }}
     {{- $proxy_protocol := when $globals.config.enable_proxy_protocol " proxy_protocol" "" }}
+    {{- $vhostFileName := $vhost.is_regexp | ternary (sha1 $hostname) $hostname }}
 
     {{- range $path, $vpath := $vhost.paths }}
 # {{ $hostname }}{{ $path }}
@@ -987,6 +988,12 @@ server {
     }
         {{- end }}
 
+        {{- if (exists (printf "/etc/nginx/vhost.d/%s" $vhostFileName)) }}
+    include {{ printf "/etc/nginx/vhost.d/%s" (replace $vhostFileName "*" "\\*" -1) }};
+        {{- else if (exists "/etc/nginx/vhost.d/default") }}
+    include /etc/nginx/vhost.d/default;
+        {{- end }}
+
         {{- if $vhost.enable_debug_endpoint }}
             {{ template "debug_location" (dict "GlobalConfig" $globals.config "Hostname" $hostname "VHost" $vhost) }}
         {{- end }}
@@ -1001,6 +1008,13 @@ server {
             return {{ $vhost.non_get_redirect }} {{ $redirect_uri }};
         }
         {{- end}}
+
+        {{- if (exists (printf "/etc/nginx/vhost.d/%s_location" $vhostFileName)) }}
+        include {{ printf "/etc/nginx/vhost.d/%s_location" (replace $vhostFileName "*" "\\*" -1) }};
+        {{- else if (exists "/etc/nginx/vhost.d/default_location") }}
+        include /etc/nginx/vhost.d/default_location;
+        {{- end }}
+
         return 301 {{ $redirect_uri }};
     }
 }
@@ -1099,8 +1113,6 @@ server {
     ssl_reject_handshake on;
         {{- end }}
     {{- end }}
-
-    {{- $vhostFileName :=  $vhost.is_regexp | ternary (sha1 $hostname) $hostname }}
 
     {{- if (exists (printf "/etc/nginx/vhost.d/%s" $vhostFileName)) }}
     include {{ printf "/etc/nginx/vhost.d/%s" (replace $vhostFileName "*" "\\*" -1) }};

--- a/test/test_ssl/redirect_vhostd.conf
+++ b/test/test_ssl/redirect_vhostd.conf
@@ -1,0 +1,1 @@
+add_header X-Test "redirect-vhostd" always;

--- a/test/test_ssl/test_redirect_vhostd.py
+++ b/test/test_ssl/test_redirect_vhostd.py
@@ -1,0 +1,9 @@
+def test_vhostd_files_included_in_redirect_server_block(docker_compose, nginxproxy):
+    conf = nginxproxy.get_conf().decode("ASCII")
+    # With a certificate present, nginx-proxy.tld gets an https_method=redirect server
+    # block in addition to the main server block. The server-level vhost.d include must
+    # now appear in BOTH (it previously appeared only in the main block).
+    assert conf.count("include /etc/nginx/vhost.d/nginx-proxy.tld;") == 2
+    # Likewise the per-vhost location include must appear in both the redirect `location /`
+    # and the main `location /`.
+    assert conf.count("include /etc/nginx/vhost.d/nginx-proxy.tld_location;") == 2

--- a/test/test_ssl/test_redirect_vhostd.yml
+++ b/test/test_ssl/test_redirect_vhostd.yml
@@ -1,0 +1,13 @@
+services:
+  nginx-proxy:
+    volumes:
+      - ${PYTEST_MODULE_PATH}/redirect_vhostd.conf:/etc/nginx/vhost.d/nginx-proxy.tld:ro
+      - ${PYTEST_MODULE_PATH}/redirect_vhostd.conf:/etc/nginx/vhost.d/nginx-proxy.tld_location:ro
+
+  web1:
+    image: web
+    expose:
+      - "81"
+    environment:
+      WEB_PORTS: "81"
+      VIRTUAL_HOST: "nginx-proxy.tld"


### PR DESCRIPTION
## What this does (#1613)

The `https_method=redirect` server block (the one that 301-redirects HTTP to HTTPS) did not include any `vhost.d` files, so there was no way to customize the redirect responses (e.g. add response headers). The main server block already includes them. This change makes the redirect block include the same files, mirroring the main block:

- **server level**: `include /etc/nginx/vhost.d/<host>;` with `default` fallback;
- **inside `location /`** (before `return 301`): `include /etc/nginx/vhost.d/<host>_location;` with `default_location` fallback.

`$vhostFileName` is hoisted so both the redirect and the main server block share the same value (regex vhosts still use the sha1 hash + `*` escaping).

### Relation to #1618

This supersedes #1618, which proposed the same feature but predates the current template. Importantly, #1618 had to make the ACME-challenge `location` conditional on the vhost.d include (a hack that relied on acme-companion having injected the challenge block, which @buchdag flagged as needing a detection mechanism). The current template already gates the ACME-challenge block on `$vhost.acme_http_challenge_legacy` / `$vhost.acme_http_challenge_enabled`, so **this change does not touch the ACME logic at all** — it only adds the includes. It also adds a test and docs.

### Tests & docs

- `test/test_ssl/test_redirect_vhostd.py` asserts (via the generated config) that both the server-level and `location`-level vhost.d includes now appear in **both** the redirect and the main server block.
- A note is added to the per-`VIRTUAL_HOST` configuration docs.

Verified locally: the new test passes against a `nginxproxy/nginx-proxy:test` image built from this branch.

Closes #1613
Supersedes #1618

🤖 Generated with [Claude Code](https://claude.com/claude-code)
