### PR TITLE
test: replace fixed startup sleep with deterministic readiness checks

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -389,22 +389,237 @@ def docker_compose_down(compose_files: List[str], project_name: str):
     __prepare_and_execute_compose_cmd(compose_files, project_name, cmd="down --volumes")
 
 
-def wait_for_nginxproxy_to_be_ready():
-    """
-    Wait for logs of running containers started from image nginxproxy/nginx-proxy:test and/or
-    nginxproxy/nginx-proxy:test-dockergen to contain the substring "Watching docker events"
-    """
-    nginx_proxy_containers = docker_client.containers.list(filters={"status": "running", "ancestor": "nginxproxy/nginx-proxy:test"})
-    docker_gen_containers = docker_client.containers.list(filters={"status": "running", "ancestor": "nginxproxy/nginx-proxy:test-dockergen"})
+DEFAULT_NGINX_CONTAINER_LABEL = "com.github.nginx-proxy.nginx-proxy.nginx"
 
-    containers = nginx_proxy_containers + docker_gen_containers
+
+def _container_image(container: Container) -> str:
+    return container.attrs.get("Config", {}).get("Image", "")
+
+
+def _container_environment(container: Container) -> dict:
+    environment = {}
+    for value in container.attrs.get("Config", {}).get("Env") or []:
+        name, separator, content = value.partition("=")
+        if separator:
+            environment[name] = content
+    return environment
+
+
+def _nginx_worker_pids(container: Container) -> set[str]:
+    """Return the PIDs of nginx workers currently running in a container."""
+    process_list = container.top(ps_args="-eo pid,args")
+    titles = process_list.get("Titles", [])
+    try:
+        pid_index = titles.index("PID")
+        command_index = titles.index("COMMAND")
+    except ValueError as error:
+        raise RuntimeError(
+            f"Unexpected process list returned by {container.name}: {titles}"
+        ) from error
+
+    return {
+        process[pid_index]
+        for process in process_list.get("Processes", [])
+        if "nginx: worker process" in process[command_index]
+    }
+
+
+def _exec_result(result) -> tuple[int, bytes]:
+    """Normalize docker-py's ExecResult and legacy tuple return values."""
+    if hasattr(result, "exit_code"):
+        return result.exit_code, result.output
+    return result
+
+
+def _container_log_tail(container: Container, lines: int = 30) -> str:
+    try:
+        logs = container.logs(tail=lines).decode("utf-8", "replace")
+    except Exception as error:
+        return f"unable to read logs: {error}"
+    return logs
+
+
+def _container_is_running(container: Container) -> bool:
+    try:
+        container.reload()
+    except docker.errors.NotFound:
+        return False
+    return container.attrs.get("State", {}).get("Running", False)
+
+
+def _wait_for_docker_gen(
+        container: Container,
+        deadline: float,
+        interval: float
+) -> bool:
+    while time.monotonic() < deadline:
+        if b"Watching docker events" in container.logs():
+            logging.debug(f"docker-gen ready in {container.name}")
+            return True
+        if not _container_is_running(container):
+            logging.debug(
+                f"ignoring {container.name}: it exited before docker-gen became ready"
+            )
+            return False
+        time.sleep(interval)
+    raise RuntimeError(
+        f"Timed out waiting for docker-gen in {container.name} to watch events.\n"
+        f"Recent logs:\n{_container_log_tail(container)}"
+    )
+
+
+def _wait_for_web_container(container: Container, deadline: float, interval: float):
+    ports = _container_environment(container).get("WEB_PORTS", "").split()
+    if not ports:
+        return
+
+    probe = (
+        "import socket, sys; "
+        "connections = [socket.create_connection(('127.0.0.1', int(port)), 0.2) "
+        "for port in sys.argv[1:]]; "
+        "[connection.close() for connection in connections]"
+    )
+    output = b""
+    while time.monotonic() < deadline:
+        if not _container_is_running(container):
+            raise RuntimeError(
+                f"Backend container {container.name} exited before becoming ready.\n"
+                f"Recent logs:\n{_container_log_tail(container)}"
+            )
+        exit_code, output = _exec_result(
+            container.exec_run(["python3", "-c", probe, *ports])
+        )
+        if exit_code == 0:
+            logging.debug(
+                f"backend ready in {container.name} on ports {ports}"
+            )
+            return
+        time.sleep(interval)
+    raise RuntimeError(
+        f"Timed out waiting for backend {container.name} to listen on ports {ports}. "
+        f"Probe output: {output.decode('utf-8', 'replace')}\n"
+        f"Recent logs:\n{_container_log_tail(container)}"
+    )
+
+
+def _reload_nginx_and_wait(container: Container, deadline: float, interval: float):
+    test_output = b""
+    workers = set()
+    while time.monotonic() < deadline:
+        exit_code, test_output = _exec_result(container.exec_run(["nginx", "-t"]))
+        if exit_code == 0:
+            workers = _nginx_worker_pids(container)
+            if workers:
+                break
+        time.sleep(interval)
+    else:
+        raise RuntimeError(
+            f"Timed out waiting for nginx in {container.name} to become valid and start workers. "
+            f"nginx -t output: {test_output.decode('utf-8', 'replace')}\n"
+            f"Recent logs:\n{_container_log_tail(container)}"
+        )
+
+    exit_code, reload_output = _exec_result(container.exec_run(["nginx", "-s", "reload"]))
+    if exit_code != 0:
+        raise RuntimeError(
+            f"Failed to reload nginx in {container.name}: "
+            f"{reload_output.decode('utf-8', 'replace')}\n"
+            f"Recent logs:\n{_container_log_tail(container)}"
+        )
+
+    while time.monotonic() < deadline:
+        new_workers = _nginx_worker_pids(container) - workers
+        if new_workers:
+            logging.debug(
+                f"nginx reloaded in {container.name}; new workers: {sorted(new_workers)}"
+            )
+            return
+        time.sleep(interval)
+    raise RuntimeError(
+        f"Timed out waiting for new nginx workers after reloading {container.name}.\n"
+        f"Recent logs:\n{_container_log_tail(container)}"
+    )
+
+
+def wait_for_nginxproxy_to_be_ready(
+        project_name: str,
+        timeout: float = 30.0,
+        interval: float = 0.1
+):
+    """Wait until docker-gen's initial config is loaded by new nginx workers."""
+    containers = docker_client.containers.list(filters={
+        "status": "running",
+        "label": f"com.docker.compose.project={project_name}",
+    })
+    docker_gen_containers = []
+    nginx_containers = []
+    nginx_container_labels = set()
 
     for container in containers:
-        logging.debug(f"waiting for container {container.name} to be ready")
-        for line in container.logs(stream=True):
-            if b"Watching docker events" in line:
-                logging.debug(f"{container.name} ready")
-                break
+        image = _container_image(container)
+        if image == "nginxproxy/nginx-proxy:test-dockergen":
+            docker_gen_containers.append(container)
+            nginx_container_labels.add(
+                _container_environment(container).get(
+                    "NGINX_CONTAINER_LABEL", DEFAULT_NGINX_CONTAINER_LABEL
+                )
+            )
+        elif image == "nginxproxy/nginx-proxy:test":
+            docker_gen_containers.append(container)
+            nginx_containers.append(container)
+
+    for container in containers:
+        labels = container.attrs.get("Config", {}).get("Labels") or {}
+        if any(label in labels for label in nginx_container_labels):
+            nginx_containers.append(container)
+
+    docker_gen_containers = list({
+        container.id: container for container in docker_gen_containers
+    }.values())
+    nginx_containers = list({
+        container.id: container for container in nginx_containers
+    }.values())
+    if not docker_gen_containers or not nginx_containers:
+        raise RuntimeError(
+            f"Could not find both docker-gen and nginx containers for Compose project "
+            f"{project_name}: docker-gen={[c.name for c in docker_gen_containers]}, "
+            f"nginx={[c.name for c in nginx_containers]}"
+        )
+
+    deadline = time.monotonic() + timeout
+    ready_docker_gen_containers = []
+    for container in docker_gen_containers:
+        if _wait_for_docker_gen(container, deadline, interval):
+            ready_docker_gen_containers.append(container)
+
+    ready_docker_gen_ids = {
+        container.id for container in ready_docker_gen_containers
+    }
+    has_ready_separate_docker_gen = any(
+        _container_image(container) == "nginxproxy/nginx-proxy:test-dockergen"
+        for container in ready_docker_gen_containers
+    )
+    nginx_containers = [
+        container for container in nginx_containers
+        if (
+            container.id in ready_docker_gen_ids
+            or (
+                has_ready_separate_docker_gen
+                and _container_image(container) != "nginxproxy/nginx-proxy:test"
+            )
+        )
+    ]
+    if not ready_docker_gen_containers or not nginx_containers:
+        raise RuntimeError(
+            f"No running docker-gen/nginx pair became ready for Compose project "
+            f"{project_name}"
+        )
+
+    for container in containers:
+        if _container_image(container) == "web":
+            _wait_for_web_container(container, deadline, interval)
+    for container in nginx_containers:
+        _reload_nginx_and_wait(container, deadline, interval)
 
 
 @pytest.fixture
@@ -560,8 +775,7 @@ class DockerComposer(contextlib.AbstractContextManager):
         try:
             docker_compose_up(docker_compose_files, project_name)
             self._networks = connect_to_all_networks()
-            wait_for_nginxproxy_to_be_ready()
-            time.sleep(3)  # give time to containers to be ready
+            wait_for_nginxproxy_to_be_ready(project_name)
 
         except KeyboardInterrupt:
             logging.warning("KeyboardInterrupt detected! Force cleanup...")
@@ -575,10 +789,13 @@ class DockerComposer(contextlib.AbstractContextManager):
             pytest.fail(f"Docker Compose setup failed due to Docker API error: {e.explanation}")
 
         except RuntimeError as e:
-            logging.error(f"RuntimeEror encountered in: {project_name}")
+            logging.error(f"RuntimeError encountered in: {project_name}")
             logging.debug(f"Full error message: {str(e)}")
             self._down()  # Ensure proper cleanup even on failure
-            pytest.fail(f"Docker Compose setup failed due to RuntimeError in: {project_name}")
+            pytest.fail(
+                f"Docker Compose setup failed in {project_name}: {e}",
+                pytrace=False,
+            )
 
 
 ###############################################################################

--- a/test/test_conftest_readiness.py
+++ b/test/test_conftest_readiness.py
@@ -1,0 +1,205 @@
+from types import SimpleNamespace
+
+import pytest
+
+import conftest
+
+
+class FakeContainer:
+    def __init__(
+            self,
+            name,
+            image,
+            *,
+            environment=None,
+            labels=None,
+            logs=b"Watching docker events",
+            worker_generations=None,
+            reload_exit_code=0,
+            running=True,
+            web_probe_failures=0,
+    ):
+        self.name = name
+        self.id = name
+        self.attrs = {
+            "Config": {
+                "Image": image,
+                "Env": environment or [],
+                "Labels": labels or {},
+            },
+            "State": {"Running": running},
+        }
+        self._logs = logs
+        self._worker_generations = worker_generations or [{"10"}, {"20"}]
+        self._top_calls = 0
+        self._reload_exit_code = reload_exit_code
+        self._web_probe_failures = web_probe_failures
+        self.exec_calls = []
+
+    def logs(self, **kwargs):
+        return self._logs
+
+    def exec_run(self, command):
+        self.exec_calls.append(command)
+        if command == ["nginx", "-t"]:
+            return SimpleNamespace(exit_code=0, output=b"configuration is valid")
+        if command[0:2] == ["python3", "-c"]:
+            if self._web_probe_failures:
+                self._web_probe_failures -= 1
+                return SimpleNamespace(exit_code=1, output=b"connection refused")
+            return SimpleNamespace(exit_code=0, output=b"")
+        return SimpleNamespace(exit_code=self._reload_exit_code, output=b"reload output")
+
+    def reload(self):
+        pass
+
+    def top(self, **kwargs):
+        index = min(self._top_calls, len(self._worker_generations) - 1)
+        self._top_calls += 1
+        processes = [
+            [pid, "nginx: worker process"]
+            for pid in sorted(self._worker_generations[index])
+        ]
+        return {"Titles": ["PID", "COMMAND"], "Processes": processes}
+
+
+class FakeContainers:
+    def __init__(self, containers):
+        self._containers = containers
+        self.filters = None
+
+    def list(self, filters):
+        self.filters = filters
+        return self._containers
+
+
+def test_wait_for_combined_proxy_reloads_and_waits_for_new_worker(monkeypatch):
+    proxy = FakeContainer("proxy", "nginxproxy/nginx-proxy:test")
+    containers = FakeContainers([proxy])
+    monkeypatch.setattr(
+        conftest, "docker_client", SimpleNamespace(containers=containers)
+    )
+
+    conftest.wait_for_nginxproxy_to_be_ready("example", timeout=1, interval=0)
+
+    assert containers.filters == {
+        "status": "running",
+        "label": "com.docker.compose.project=example",
+    }
+    assert proxy.exec_calls == [["nginx", "-t"], ["nginx", "-s", "reload"]]
+
+
+def test_wait_for_separate_containers_honors_custom_nginx_label(monkeypatch):
+    dockergen = FakeContainer(
+        "dockergen",
+        "nginxproxy/nginx-proxy:test-dockergen",
+        environment=["NGINX_CONTAINER_LABEL=example.proxy"],
+    )
+    nginx = FakeContainer("nginx", "nginx:latest", labels={"example.proxy": ""})
+    unrelated = FakeContainer("backend", "nginx:alpine")
+    monkeypatch.setattr(
+        conftest,
+        "docker_client",
+        SimpleNamespace(
+            containers=FakeContainers([dockergen, nginx, unrelated])
+        ),
+    )
+
+    conftest.wait_for_nginxproxy_to_be_ready("example", timeout=1, interval=0)
+
+    assert nginx.exec_calls == [["nginx", "-t"], ["nginx", "-s", "reload"]]
+    assert dockergen.exec_calls == []
+    assert unrelated.exec_calls == []
+
+
+def test_wait_for_multiple_combined_proxies(monkeypatch):
+    first = FakeContainer("first", "nginxproxy/nginx-proxy:test")
+    second = FakeContainer("second", "nginxproxy/nginx-proxy:test")
+    monkeypatch.setattr(
+        conftest,
+        "docker_client",
+        SimpleNamespace(containers=FakeContainers([first, second])),
+    )
+
+    conftest.wait_for_nginxproxy_to_be_ready("example", timeout=1, interval=0)
+
+    expected_calls = [["nginx", "-t"], ["nginx", "-s", "reload"]]
+    assert first.exec_calls == expected_calls
+    assert second.exec_calls == expected_calls
+
+
+def test_waits_for_web_ports_without_requesting_through_nginx(monkeypatch):
+    proxy = FakeContainer("proxy", "nginxproxy/nginx-proxy:test")
+    backend = FakeContainer(
+        "backend",
+        "web",
+        environment=["WEB_PORTS=81 82"],
+        web_probe_failures=1,
+    )
+    monkeypatch.setattr(
+        conftest,
+        "docker_client",
+        SimpleNamespace(containers=FakeContainers([proxy, backend])),
+    )
+
+    conftest.wait_for_nginxproxy_to_be_ready("example", timeout=1, interval=0)
+
+    probe_calls = [call for call in backend.exec_calls if call[0:2] == ["python3", "-c"]]
+    assert len(probe_calls) == 2
+    assert probe_calls[-1][-2:] == ["81", "82"]
+
+
+def test_ignores_proxy_that_exits_before_docker_gen_is_ready(monkeypatch):
+    healthy = FakeContainer("healthy", "nginxproxy/nginx-proxy:test")
+    invalid = FakeContainer(
+        "invalid",
+        "nginxproxy/nginx-proxy:test",
+        logs=b"invalid configuration",
+        running=False,
+    )
+    monkeypatch.setattr(
+        conftest,
+        "docker_client",
+        SimpleNamespace(containers=FakeContainers([healthy, invalid])),
+    )
+
+    conftest.wait_for_nginxproxy_to_be_ready("example", timeout=1, interval=0)
+
+    assert healthy.exec_calls == [["nginx", "-t"], ["nginx", "-s", "reload"]]
+    assert invalid.exec_calls == []
+
+
+def test_reload_failure_is_not_silently_ignored():
+    nginx = FakeContainer(
+        "nginx", "nginxproxy/nginx-proxy:test", reload_exit_code=1
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to reload nginx in nginx"):
+        conftest._reload_nginx_and_wait(
+            nginx, conftest.time.monotonic() + 1, 0
+        )
+
+
+def test_worker_replacement_timeout_is_not_silently_ignored():
+    nginx = FakeContainer(
+        "nginx",
+        "nginxproxy/nginx-proxy:test",
+        worker_generations=[{"10"}],
+    )
+
+    with pytest.raises(RuntimeError, match="Timed out waiting for new nginx workers"):
+        conftest._reload_nginx_and_wait(
+            nginx, conftest.time.monotonic() + 0.01, 0
+        )
+
+
+def test_missing_proxy_role_is_an_error(monkeypatch):
+    backend = FakeContainer("backend", "nginx:alpine")
+    monkeypatch.setattr(
+        conftest,
+        "docker_client",
+        SimpleNamespace(containers=FakeContainers([backend])),
+    )
+
+    with pytest.raises(RuntimeError, match="Could not find both docker-gen and nginx"):
+        conftest.wait_for_nginxproxy_to_be_ready("example", timeout=1, interval=0)


### PR DESCRIPTION
## What

Replace the fixed `time.sleep(3)` after `docker compose up` with deterministic readiness checks for docker-gen, test backends, and nginx.

## Why

The integration suite intermittently raced container startup, especially on the slower Debian matrix job. A request could arrive while:

- docker-gen had not finished its initial render;
- the generated config had been written but nginx had not loaded it into new workers yet; or
- the test backend process had not started listening, resulting in a transient 502.

Checking only for a vhost in `/etc/nginx/conf.d/default.conf` is not sufficient: docker-gen writes the file before the nginx reload has completed, so a test can still be served by the previous configuration. Relying on request-level 404/502 retries also polluted nginx logs and did not help tests that use raw sockets.

## How

`DockerComposer.compose()` now waits for the actual startup lifecycle:

1. Scope all checks to the current Compose project.
2. Wait for each running docker-gen instance to reach `Watching docker events`.
3. For test `web` containers, probe every declared `WEB_PORTS` port from inside the container until it is listening. This avoids sending readiness traffic through nginx or polluting its access/error logs.
4. Validate nginx with `nginx -t`, trigger an explicit reload, and wait until new nginx worker PIDs appear — which is what actually guarantees the generated configuration is the one serving requests.

The discovery logic supports:

- the combined nginx-proxy image;
- separate nginx and docker-gen containers;
- custom `NGINX_CONTAINER_LABEL` values; and
- Compose projects containing multiple proxy instances.

Containers that intentionally exit before docker-gen becomes ready, such as the invalid DH parameter test fixture, are excluded as long as another usable docker-gen/nginx pair remains.

All readiness checks share a 30-second deadline. A timeout, invalid nginx configuration, failed reload, exited backend, or missing proxy pair fails setup with container logs instead of silently continuing.

The existing per-request 404/502 retry remains as a backstop for tests that intentionally change containers after initial startup.

## Tests

`test_conftest_readiness.py` covers the readiness logic without requiring docker:

- combined and separate-container setups;
- custom nginx labels;
- multiple proxy instances;
- backend port readiness;
- intentionally exited proxy containers;
- reload failures and worker replacement timeouts; and
- missing proxy roles.

Verified locally against the Debian image (270 passed), covering the modules that were failing on CI plus the multi-proxy and docker-gen ones (`test_ssl`, `test_fallback`, `test_custom`, `test_acme-http-challenge-location`, `test_logs`, `test_resolvers`, `test_dockergen`, `test_server-down`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
