### PR TITLE
feat: dockergen image w/ bundled nginx-proxy template

### DIFF
--- a/.github/workflows/build-publish-dispatch.yml
+++ b/.github/workflows/build-publish-dispatch.yml
@@ -14,10 +14,10 @@ on:
 
 jobs:
   multiarch-build:
-    name: Build and publish ${{ matrix.base }} image with tag ${{ inputs.image_tag }}
+    name: Build and publish ${{ matrix.flavor }} image with tag ${{ inputs.image_tag }}
     strategy:
       matrix:
-        base: [alpine, debian]
+        flavor: [alpine, debian, dockergen]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,7 +31,7 @@ jobs:
 
       - name: Retrieve docker-gen version
         id: docker-gen_version
-        run: sed -n -e 's;^FROM docker.io/nginxproxy/docker-gen:\([0-9.]*\).*;VERSION=\1;p' Dockerfile.${{ matrix.base }} >> "$GITHUB_OUTPUT"
+        run: sed -n -e 's;^FROM docker.io/nginxproxy/docker-gen:\([0-9.]*\).*;VERSION=\1;p' Dockerfile.${{ matrix.flavor }} >> "$GITHUB_OUTPUT"
 
       - name: Get Docker tags
         id: docker_meta
@@ -40,8 +40,9 @@ jobs:
           images: |
             nginxproxy/nginx-proxy
           tags: |
-            type=raw,value=${{ inputs.image_tag }},enable=${{ matrix.base == 'debian' }}
-            type=raw,value=${{ inputs.image_tag }},suffix=-alpine,enable=${{ matrix.base == 'alpine' }}
+            type=raw,value=${{ inputs.image_tag }},enable=${{ matrix.flavor == 'debian' }}
+            type=raw,value=${{ inputs.image_tag }},suffix=-alpine,enable=${{ matrix.flavor == 'alpine' }}
+            type=raw,value=${{ inputs.image_tag }},suffix=-dockergen,enable=${{ matrix.flavor == 'dockergen' }}
           labels: |
             org.opencontainers.image.authors=Nicolas Duchon <nicolas.duchon@gmail.com> (@buchdag), Jason Wilder
             org.opencontainers.image.version=${{ steps.nginx-proxy_version.outputs.VERSION }}
@@ -72,7 +73,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: Dockerfile.${{ matrix.base }}
+          file: Dockerfile.${{ matrix.flavor }}
           build-args: |
             NGINX_PROXY_VERSION=${{ steps.nginx-proxy_version.outputs.VERSION }}
             DOCKER_GEN_VERSION=${{ steps.docker-gen_version.outputs.VERSION }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -24,10 +24,10 @@ on:
 
 jobs:
   multiarch-build:
-    name: Build and publish image
+    name: Build and publish ${{ matrix.flavor }} image
     strategy:
       matrix:
-        base: [alpine, debian]
+        flavor: [alpine, debian, dockergen]
     runs-on: ubuntu-latest
     if: (github.event_name == 'schedule' && github.repository == 'nginx-proxy/nginx-proxy') || (github.event_name != 'schedule')
     steps:
@@ -42,7 +42,7 @@ jobs:
 
       - name: Retrieve docker-gen version
         id: docker-gen_version
-        run: sed -n -e 's;^FROM docker.io/nginxproxy/docker-gen:\([0-9.]*\).*;VERSION=\1;p' Dockerfile.${{ matrix.base }} >> "$GITHUB_OUTPUT"
+        run: sed -n -e 's;^FROM docker.io/nginxproxy/docker-gen:\([0-9.]*\).*;VERSION=\1;p' Dockerfile.${{ matrix.flavor }} >> "$GITHUB_OUTPUT"
 
       - name: Get Docker tags
         id: docker_meta
@@ -53,12 +53,15 @@ jobs:
             nginxproxy/nginx-proxy
             jwilder/nginx-proxy
           tags: |
-            type=semver,pattern={{version}},enable=${{ matrix.base == 'debian' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.base == 'debian' }}
-            type=semver,suffix=-alpine,pattern={{version}},enable=${{ matrix.base == 'alpine' }}
-            type=semver,suffix=-alpine,pattern={{major}}.{{minor}},enable=${{ matrix.base == 'alpine' }}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && matrix.base == 'debian' }}
-            type=raw,value=alpine,enable=${{ github.ref == 'refs/heads/main' && matrix.base == 'alpine' }}
+            type=semver,pattern={{version}},enable=${{ matrix.flavor == 'debian' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ matrix.flavor == 'debian' }}
+            type=semver,suffix=-alpine,pattern={{version}},enable=${{ matrix.flavor == 'alpine' }}
+            type=semver,suffix=-alpine,pattern={{major}}.{{minor}},enable=${{ matrix.flavor == 'alpine' }}
+            type=semver,suffix=-dockergen,pattern={{version}},enable=${{ matrix.flavor == 'dockergen' }}
+            type=semver,suffix=-dockergen,pattern={{major}}.{{minor}},enable=${{ matrix.flavor == 'dockergen' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && matrix.flavor == 'debian' }}
+            type=raw,value=alpine,enable=${{ github.ref == 'refs/heads/main' && matrix.flavor == 'alpine' }}
+            type=raw,value=dockergen,enable=${{ github.ref == 'refs/heads/main' && matrix.flavor == 'dockergen' }}
           labels: |
             org.opencontainers.image.authors=Nicolas Duchon <nicolas.duchon@gmail.com> (@buchdag), Jason Wilder
             org.opencontainers.image.version=${{ steps.nginx-proxy_version.outputs.VERSION }}
@@ -89,7 +92,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: Dockerfile.${{ matrix.base }}
+          file: Dockerfile.${{ matrix.flavor }}
           build-args: |
             NGINX_PROXY_VERSION=${{ steps.nginx-proxy_version.outputs.VERSION }}
             DOCKER_GEN_VERSION=${{ steps.docker-gen_version.outputs.VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,11 @@ jobs:
       - name: Build Docker web server image
         run: make build-webserver
 
-      - name: Build Docker nginx proxy test image
+      - name: Build Docker nginx-proxy:test image
         run: make build-nginx-proxy-test-${{ matrix.base_docker_image }}
+      
+      - name: Build Docker nginx-proxy:test-dockergen image
+        run: make build-nginx-proxy-test-dockergen
 
       - name: Run tests
         run: pytest --ignore-flaky

--- a/Dockerfile.dockergen
+++ b/Dockerfile.dockergen
@@ -1,0 +1,27 @@
+FROM docker.io/nginxproxy/docker-gen:0.17.2
+
+ARG NGINX_PROXY_VERSION
+# Add DOCKER_GEN_VERSION environment variable because 
+# acme-companion relies on it (but the actual value is not important)
+ARG DOCKER_GEN_VERSION="unknown"
+ENV NGINX_PROXY_VERSION=${NGINX_PROXY_VERSION} \
+    DOCKER_GEN_VERSION=${DOCKER_GEN_VERSION} \
+    DOCKER_HOST=unix:///tmp/docker.sock \
+    DHPARAM_SKIP=true \
+    NGINX_CONTAINER_LABEL=com.github.nginx-proxy.nginx-proxy.nginx
+
+# Install dependencies
+RUN apk add --no-cache --virtual .run-deps bash
+
+RUN mkdir -p '/etc/nginx/conf.d' \
+    && mkdir -p '/etc/nginx/vhost.d' \
+    && mkdir -p '/etc/nginx/htpasswd' \
+    && mkdir -p '/etc/nginx/dhparam' \
+    && mkdir -p '/etc/nginx/certs' \
+    && mkdir -p '/usr/share/nginx/html/errors'
+
+COPY app nginx.tmpl LICENSE /app/
+WORKDIR /app/
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["docker-gen", "-watch", "-wait", "100ms:500ms", "-event-filter", "event=connect", "-event-filter", "event=disconnect", "-notify-filter", "label=$NGINX_CONTAINER_LABEL", "/app/nginx.tmpl", "/etc/nginx/conf.d/default.conf"]

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,13 @@ build-nginx-proxy-test-debian:
 build-nginx-proxy-test-alpine:
 	docker build --pull --build-arg NGINX_PROXY_VERSION="test" -f Dockerfile.alpine -t nginxproxy/nginx-proxy:test .
 
-test-debian: build-webserver build-nginx-proxy-test-debian
+build-nginx-proxy-test-dockergen:
+	docker build --pull --build-arg NGINX_PROXY_VERSION="test" -f Dockerfile.dockergen -t nginxproxy/nginx-proxy:test-dockergen .
+
+test-debian: build-webserver build-nginx-proxy-test-debian build-nginx-proxy-test-dockergen
 	test/pytest.sh
 
-test-alpine: build-webserver build-nginx-proxy-test-alpine
+test-alpine: build-webserver build-nginx-proxy-test-alpine build-nginx-proxy-test-dockergen
 	test/pytest.sh
 
 test: test-debian test-alpine

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -108,7 +108,7 @@ function _setup_dhparam() {
 }
 
 # Run the init logic if the default CMD was provided
-if [[ $* == 'forego start -r' ]]; then
+if [[ $* == 'forego start -r' ]] || [[ $* =~ 'docker-gen -watch' ]]; then
 	_print_version
 	
 	_check_unix_socket
@@ -123,6 +123,13 @@ if [[ $* == 'forego start -r' ]]; then
 			Warning: The default value of TRUST_DOWNSTREAM_PROXY might change to "false" in a future version of nginx-proxy. If you require TRUST_DOWNSTREAM_PROXY to be enabled, explicitly set it to "true".
 		EOT
 	fi
+
+	# Replace $NGINX_CONTAINER_LABEL in the command line arguments with the actual value of the environment variable
+	for ((i=1; i<=$#; i++)); do
+		if [[ ${!i} =~ "\$NGINX_CONTAINER_LABEL" && -n "$NGINX_CONTAINER_LABEL" ]]; then
+			set -- "${@:1:i-1}" "${!i/\$NGINX_CONTAINER_LABEL/${NGINX_CONTAINER_LABEL}}" "${@:i+1}"
+		fi
+	done
 fi
 
 exec "$@"

--- a/docker-compose-separate-containers.yml
+++ b/docker-compose-separate-containers.yml
@@ -1,28 +1,52 @@
 volumes:
   nginx_conf:
+  nginx_vhost:
+  nginx_certs:
+  nginx_htpasswd:
+  nginx_errors:
+
+networks:
+  proxy:
+  private:
+    internal: true
 
 services:
   nginx:
     image: nginx
     container_name: nginx
+    networks:
+      - proxy
     ports:
       - "80:80"
     volumes:
+      - ./network_internal.conf:/etc/nginx/network_internal.conf:ro
       - nginx_conf:/etc/nginx/conf.d:ro
-      - network_internal.conf:/etc/nginx/network_internal.conf:ro
+      - nginx_vhost:/etc/nginx/vhost.d:ro
+      - nginx_htpasswd:/etc/nginx/htpasswd:ro
+      - nginx_certs:/etc/nginx/certs:ro
+      - nginx_errors:/usr/share/nginx/html/errors:ro
+    labels:
+      - com.github.nginx-proxy.nginx-proxy.nginx
 
   dockergen:
-    image: nginxproxy/docker-gen
-    command: -notify-sighup nginx -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
-    # the name "nginx" passed to the "-notify-sighup" flag must exactly match the container name used for the nginx container above.
+    image: nginxproxy/nginx-proxy:dockergen
+    container_name: dockergen
+    networks:
+      - private
     environment:
       # nginx-proxy environment variable (HTTP_PORT etc.) must be set on the docker-gen container (not the nginx container)  
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ./nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl
-      - nginx_conf:/etc/nginx/conf.d
+      - nginx_conf:/etc/nginx/conf.d # not read-only because docker-gen needs to write the generated config
+      - nginx_vhost:/etc/nginx/vhost.d:ro
+      - nginx_htpasswd:/etc/nginx/htpasswd:ro
+      - nginx_certs:/etc/nginx/certs:ro
+      - nginx_errors:/usr/share/nginx/html/errors:ro
 
   whoami:
     image: jwilder/whoami
+    container_name: whoami
+    networks:
+      - proxy
     environment:
       - VIRTUAL_HOST=whoami.example

--- a/docs/README.md
+++ b/docs/README.md
@@ -1299,9 +1299,9 @@ See the [Docker CLI documentation](https://docs.docker.com/reference/cli/docker/
 
 ## Separate Containers
 
-nginx-proxy can also be run as two separate containers using the [nginxproxy/docker-gen](https://hub.docker.com/r/nginxproxy/docker-gen) image and the official [nginx](https://registry.hub.docker.com/_/nginx/) image.
+nginx-proxy can also be run as two separate containers using the [nginxproxy/nginx-proxy:dockergen](https://hub.docker.com/repository/docker/nginxproxy/nginx-proxy/tags/dockergen) image and the official [nginx](https://registry.hub.docker.com/_/nginx/) image.
 
-You may want to do this to prevent having the docker socket bound to a publicly exposed container service.
+You may want to do this to prevent having the docker socket bound to a publicly exposed container service (you should run the docker-gen container in an [internal network](https://docs.docker.com/reference/cli/docker/network/create/#internal), unreachable from the outside).
 
 You can demo this pattern with docker compose:
 
@@ -1316,27 +1316,32 @@ Example output:
 I'm 5b129ab83266
 ```
 
-To run nginx proxy as a separate container you'll need to have [nginx.tmpl](https://github.com/nginx-proxy/nginx-proxy/blob/main/nginx.tmpl) on your host system.
-
-First start nginx with a volume mounted to `/etc/nginx/conf.d`:
+First start nginx with a volume mounted to `/etc/nginx/conf.d` and the label `com.github.nginx-proxy.nginx-proxy.nginx`:
 
 ```console
 docker run --detach \
     --name nginx \
     --publish 80:80 \
-    --volume /tmp/nginx:/etc/nginx/conf.d \
+    --volume /tmp/nginx/conf.d:/etc/nginx/conf.d \
+    --label "com.github.nginx-proxy.nginx-proxy.nginx" \
     nginx
 ```
 
-Then start the docker-gen container with the shared volume and template:
+Create an internal network to isolate the docker-gen container:
+
+```console
+docker network create --internal nginx-gen
+```
+
+Then start the docker-gen container on the internal network, with the shared volume:
 
 ```console
 docker run --detach \
     --name docker-gen \
     --volumes-from nginx \
     --volume /var/run/docker.sock:/tmp/docker.sock:ro \
-    --volume $(pwd):/etc/docker-gen/templates \
-    nginxproxy/docker-gen -notify-sighup nginx -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+    --network nginx-gen \
+    nginxproxy/nginx-proxy:dockergen
 ```
 
 Finally, start your containers with `VIRTUAL_HOST` environment variables.
@@ -1345,39 +1350,42 @@ Finally, start your containers with `VIRTUAL_HOST` environment variables.
 docker run --env VIRTUAL_HOST=foo.bar.com  ...
 ```
 
-### Network segregation
-
-To allow for network segregation of the nginx and docker-gen containers, the label `com.github.nginx-proxy.nginx-proxy.nginx` must be applied to the nginx container, otherwise it is assumed that nginx and docker-gen share the same network:
+You can also customise the label being used by docker-gen to find the nginx container with the `NGINX_CONTAINER_LABEL` environment variable (on the docker-gen container):
 
 ```console
-docker run --detach \
-    --name nginx \
-    --publish 80:80 \
-    --label "com.github.nginx-proxy.nginx-proxy.nginx" \
-    --volume /tmp/nginx:/etc/nginx/conf.d \
-    nginx
-```
-
-Network segregation make it possible to run the docker-gen container in an [internal network](https://docs.docker.com/reference/cli/docker/network/create/#internal), unreachable from the outside.
-
-You can also customise the label being used by docker-gen to find the nginx container with the `NGINX_CONTAINER_LABEL`environment variable (on the docker-gen container):
-
-```console
-docker run --detach \
-    --name docker-gen \
-    --volumes-from nginx \
-    --volume /var/run/docker.sock:/tmp/docker.sock:ro \
-    --volume $(pwd):/etc/docker-gen/templates \
-    --env "NGINX_CONTAINER_LABEL=com.github.foobarbuzz" \
-    nginxproxy/docker-gen -notify-sighup nginx -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
-
 docker run --detach \
     --name nginx \
     --publish 80:80 \
     --label "com.github.foobarbuzz" \
-    --volume "/tmp/nginx:/etc/nginx/conf.d" \
+    --volume "/tmp/nginx/conf.d:/etc/nginx/conf.d" \
     nginx
+
+docker network create --internal nginx-gen
+
+docker run --detach \
+    --name docker-gen \
+    --volumes-from nginx \
+    --volume /var/run/docker.sock:/tmp/docker.sock:ro \
+    --network nginx-gen \
+    --env "NGINX_CONTAINER_LABEL=com.github.foobarbuzz" \
+    nginxproxy/nginx-proxy:dockergen
 ```
+
+> [!WARNING]
+> When `nginx` and `docker-gen` run in separate containers, they **must share the same files** used by template `exists` checks and generated `include` directives.
+> `/etc/nginx/conf.d` is the bare minimum required for nginx-proxy to work, but you may also want to share `/etc/nginx/certs`, `/etc/nginx/vhost.d`, `/etc/nginx/htpasswd`, and `/usr/share/nginx/html` if you use the features that require them.
+> If these paths are not shared, `docker-gen` may render a config that does not match what `nginx` can actually read.
+
+Recommended shared volumes between `nginx` and `docker-gen`:
+
+| Container path | Why it must be shared | docker-gen access |
+| --- | --- | --- |
+| `/etc/nginx/conf.d` | `docker-gen` writes generated vhost config files that `nginx` loads. | read-write |
+| `/etc/nginx/certs` | Template checks certificate files (`*.crt`, `*.key`, `*.chain.pem`, `*.dhparam.pem`, etc.). | read-only |
+| `/etc/nginx/vhost.d` | Template checks and includes per-vhost/per-location override files. | read-only |
+| `/etc/nginx/htpasswd` | Template checks and includes basic auth files. | read-only |
+| `/usr/share/nginx/html` | Template may use this path for ACME challenge files and fallback error pages. | read-only |
+
 
 ⬆️ [back to table of contents](#table-of-contents)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -392,10 +392,10 @@ def docker_compose_down(compose_files: List[str], project_name: str):
 def wait_for_nginxproxy_to_be_ready():
     """
     Wait for logs of running containers started from image nginxproxy/nginx-proxy:test and/or
-    nginxproxy/docker-gen:latest to contain the substring "Watching docker events"
+    nginxproxy/nginx-proxy:test-dockergen to contain the substring "Watching docker events"
     """
     nginx_proxy_containers = docker_client.containers.list(filters={"status": "running", "ancestor": "nginxproxy/nginx-proxy:test"})
-    docker_gen_containers = docker_client.containers.list(filters={"status": "running", "ancestor": "nginxproxy/docker-gen:latest"})
+    docker_gen_containers = docker_client.containers.list(filters={"status": "running", "ancestor": "nginxproxy/nginx-proxy:test-dockergen"})
 
     containers = nginx_proxy_containers + docker_gen_containers
 

--- a/test/test_dockergen/test_dockergen.base.yml
+++ b/test/test_dockergen/test_dockergen.base.yml
@@ -11,13 +11,13 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    labels:
+      - "com.github.nginx-proxy.nginx-proxy.nginx"
 
   nginx-proxy-dockergen:
-    image: nginxproxy/docker-gen
-    command: -notify-sighup nginx -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+    image: nginxproxy/nginx-proxy:test-dockergen
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ../../nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl
       - nginx_conf:/etc/nginx/conf.d
 
   web:

--- a/test/test_dockergen/test_dockergen_network_segregation-custom-label.base.yml
+++ b/test/test_dockergen/test_dockergen_network_segregation-custom-label.base.yml
@@ -22,11 +22,9 @@ services:
       - "com.github.nginx-proxy.nginx-proxy.foobarbuzz"
 
   nginx-proxy-dockergen:
-    image: nginxproxy/docker-gen
-    command: -notify-sighup nginx -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+    image: nginxproxy/nginx-proxy:test-dockergen
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ../../nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl
       - nginx_conf:/etc/nginx/conf.d
     environment:
       NGINX_CONTAINER_LABEL: "com.github.nginx-proxy.nginx-proxy.foobarbuzz"

--- a/test/test_dockergen/test_dockergen_network_segregation.base.yml
+++ b/test/test_dockergen/test_dockergen_network_segregation.base.yml
@@ -22,11 +22,9 @@ services:
       - "com.github.nginx-proxy.nginx-proxy.nginx"
 
   nginx-proxy-dockergen:
-    image: nginxproxy/docker-gen
-    command: -notify-sighup nginx -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+    image: nginxproxy/nginx-proxy:test-dockergen
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
-      - ../../nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl
       - nginx_conf:/etc/nginx/conf.d
     networks:
       - private


### PR DESCRIPTION
The PR build and publish a new `nginxproxy/nginx-proxy:dockergen` image.

This new image is essentially [docker-gen](https://github.com/nginx-proxy/docker-gen) bundled with [the nginx-proxy template](https://github.com/nginx-proxy/nginx-proxy/blob/main/nginx.tmpl) and pre configured to work in a [separate container setup](https://github.com/nginx-proxy/nginx-proxy/tree/main/docs#separate-containers). The idea is to make the separate container setup easier to use and to provide versioning of the nginx-proxy features in this setup.