### PR TITLE
Support containers sharing another container's network namespace

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -331,6 +331,12 @@ In this example, the `my-nginx-proxy` container will be connected to `my-network
 
 Proxyed containers running in host network mode **must** use the [`VIRTUAL_PORT`](#virtual-ports) environment variable, as this is the only way for `nginx-proxy` to get the correct port (or a port at all) for those containers.
 
+### Shared network namespaces
+
+`nginx-proxy` supports proxying containers that share the network namespace of another container (`network_mode: "container:name-or-id"`, or `network_mode: "service:name"` with Docker Compose). Those containers do not carry network information of their own, so `nginx-proxy` uses the networks of the container owning the namespace to reach them. The owning container must be reachable from `nginx-proxy` (see [Multiple Networks](#multiple-networks)).
+
+For port selection, only the exposed ports of the proxied container itself are considered, never those of the container owning the namespace. Note that the Docker engine rejects create-time port exposure (`--expose` / Docker Compose `expose:`) together with a container type network mode, so the proxied container's exposed ports can only come from its image's `EXPOSE` instructions. The standard fallback behavior applies: a single exposed port is used as-is, anything else requires the [`VIRTUAL_PORT`](#virtual-ports) environment variable.
+
 ### Internet vs. Local Network Access
 
 If you allow traffic from the public internet to access your `nginx-proxy` container, you may want to restrict some containers to the internal network only, so they cannot be accessed from the public internet. On containers that should be restricted to the internal network, you should set the environment variable `NETWORK_ACCESS=internal`. By default, the _internal_ network is defined as `127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16`. To change the list of networks considered internal, mount a file on the `nginx-proxy` at `/etc/nginx/network_internal.conf` with these contents, edited to suit your needs:

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -86,8 +86,20 @@
 {{- define "container_ip" }}
     {{- $ipv4 := "" }}
     {{- $ipv6 := "" }}
+    {{- $container := $.container }}
+    {{- /*
+         * Containers sharing another container's network namespace
+         * use the networks of the container owning the namespace instead.
+         */}}
+    {{- if hasPrefix "container:" $container.NetworkMode }}
+        {{- $netContainer := where $.globals.containers "ID" (trimPrefix "container:" $container.NetworkMode) | first }}
+        {{- if $netContainer }}
+    #     shares the network namespace of container {{ $netContainer.Name }}
+            {{- $container = $netContainer }}
+        {{- end }}
+    {{- end }}
     #     networks:
-    {{- range sortObjectsByKeysAsc $.container.Networks "Name" }}
+    {{- range sortObjectsByKeysAsc $container.Networks "Name" }}
         {{- /*
              * TODO: Only ignore the "ingress" network for Swarm tasks (in case
              * the user is not using Swarm mode and names a network "ingress").

--- a/test/test_container-network-mode/test_container-network-mode.py
+++ b/test/test_container-network-mode/test_container-network-mode.py
@@ -1,0 +1,9 @@
+def test_forwards_to_container_joining_another_network_namespace_on_default_port(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://netns-joiner-default-port.nginx-proxy.tld/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 80\n"
+
+def test_forwards_to_container_joining_another_network_namespace_on_custom_port(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://netns-joiner-custom-port.nginx-proxy.tld/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 8080\n"

--- a/test/test_container-network-mode/test_container-network-mode.yml
+++ b/test/test_container-network-mode/test_container-network-mode.yml
@@ -1,0 +1,24 @@
+services:
+  netns-owner:
+    # Reuses the base image of the web test image (no extra image is pulled).
+    image: python:3-alpine
+    command: tail -f /dev/null
+
+  netns-joiner-default-port:
+    image: web
+    environment:
+      WEB_PORTS: "80"
+      VIRTUAL_HOST: "netns-joiner-default-port.nginx-proxy.tld"
+    network_mode: service:netns-owner
+    depends_on:
+      - netns-owner
+
+  netns-joiner-custom-port:
+    image: web
+    environment:
+      WEB_PORTS: "8080"
+      VIRTUAL_HOST: "netns-joiner-custom-port.nginx-proxy.tld"
+      VIRTUAL_PORT: "8080"
+    network_mode: service:netns-owner
+    depends_on:
+      - netns-owner


### PR DESCRIPTION
This PR adds support for containers that share the network namespace of another container. This is a common pattern for VPN sidecar containers: an application container is joined to the network namespace of a VPN container (Tailscale, WireGuard, etc.) so its traffic can flow through the VPN.

`docker-gen` already exposes `NetworkMode`, which for these containers holds `container:<id>` of the namespace owner. This change makes `container_ip` resolve the owning container and use its networks instead. When the owning container cannot be found, the behavior is unchanged.

Tests cover the default-port fallback and explicit `VIRTUAL_PORT`. 

Note: The Docker engine rejects create-time port exposure (`--expose` /  `expose:`) combined with a container type network mode (`conflicting options: port exposing and the container type network mode`), so a joining container's exposed ports can only come from its image. I manually tested a custom image with an `EXPOSE` port (other than 80) without the `VIRTUAL_PORT` env var.